### PR TITLE
Fix issue where babel-plugin would cause other plugins to exit early

### DIFF
--- a/.changeset/eighty-queens-repeat.md
+++ b/.changeset/eighty-queens-repeat.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/babel-plugin': patch
+---
+
+Fix issue where babel-plugin would cause other babel plugins to exit early

--- a/packages/babel-plugin/src/index.ts
+++ b/packages/babel-plugin/src/index.ts
@@ -203,13 +203,13 @@ export default function (): PluginObj<Context> {
       ImportDeclaration(path) {
         if (!this.isCssFile || this.alreadyCompiled) {
           // Bail early if file isn't a .css.ts file or the file has already been compiled
-          return path.stop();
+          return;
         }
 
         if (path.node.source.value === filescopePackageIdentifier) {
           // If file scope import is found it means the file has already been compiled
           this.alreadyCompiled = true;
-          return path.stop();
+          return;
         } else if (path.node.source.value === packageIdentifier) {
           path.node.specifiers.forEach((specifier) => {
             if (t.isImportNamespaceSpecifier(specifier)) {
@@ -231,7 +231,7 @@ export default function (): PluginObj<Context> {
       CallExpression(path) {
         if (!this.isCssFile || this.alreadyCompiled) {
           // Bail early if file isn't a .css.ts file or the file has already been compiled
-          return path.stop();
+          return;
         }
 
         const { node } = path;


### PR DESCRIPTION
Turns out `path.stop()` stops traversal of a node globally, not just for the calling plugin 😅.  Removing them in favour of simple early returns resolves the issue. 

This would cause other plugins (e.g. `preset-react`, `preset-typescript`, etc) to not complete their compilation, leading to errors like the following.
```
Module parse failed: Unexpected token (8:9)
File was processed with these loaders:
 * ./node_modules/@next/react-refresh-utils/loader.js
 * ./node_modules/next/dist/build/webpack/loaders/next-babel-loader.js
You may need an additional loader to handle the result of these loaders.
|   pageProps
| }) {
>   return <Component {...pageProps} __self={this} __source={{
|     fileName: _jsxFileName,
|     lineNumber: 4,
```

Resolves #40 