### PR TITLE
Sprinkles: Allow theme vars in atomic properties

### DIFF
--- a/.changeset/calm-lamps-do.md
+++ b/.changeset/calm-lamps-do.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/sprinkles': patch
+---
+
+Allow theme vars to be passed to atomic properties

--- a/.changeset/silent-pugs-sell.md
+++ b/.changeset/silent-pugs-sell.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/css': patch
+---
+
+Export CSSProperties type

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -1,6 +1,12 @@
 import './runtimeAdapter';
 
-export type { StyleRule, GlobalStyleRule, Adapter, FileScope } from './types';
+export type {
+  StyleRule,
+  GlobalStyleRule,
+  Adapter,
+  FileScope,
+  CSSProperties,
+} from './types';
 export * from './identifier';
 export * from './theme';
 export * from './style';

--- a/packages/css/src/transformCss.ts
+++ b/packages/css/src/transformCss.ts
@@ -5,7 +5,7 @@ import type {
   CSS,
   CSSStyleBlock,
   CSSKeyframesBlock,
-  CSSProperties,
+  CSSPropertiesWithVars,
   FeatureQueries,
   MediaQueries,
   StyleRule,
@@ -173,7 +173,7 @@ const specialKeys = [...simplePseudos, '@media', '@supports', 'selectors'];
 interface CSSRule {
   conditions?: Array<string>;
   selector: string;
-  rule: CSSProperties;
+  rule: CSSPropertiesWithVars;
 }
 
 class Stylesheet {
@@ -238,12 +238,12 @@ class Stylesheet {
     }
   }
 
-  pixelifyProperties(cssRule: CSSProperties) {
+  pixelifyProperties(cssRule: CSSPropertiesWithVars) {
     forEach(cssRule, (value, key) => {
       if (
         typeof value === 'number' &&
         value !== 0 &&
-        !UNITLESS[key as keyof CSSProperties]
+        !UNITLESS[key as keyof CSSPropertiesWithVars]
       ) {
         // @ts-expect-error Any ideas?
         cssRule[key] = `${value}px`;
@@ -253,7 +253,7 @@ class Stylesheet {
     return cssRule;
   }
 
-  transformVars({ vars, ...rest }: CSSProperties) {
+  transformVars({ vars, ...rest }: CSSPropertiesWithVars) {
     if (!vars) {
       return rest;
     }
@@ -384,7 +384,7 @@ class Stylesheet {
         this.addRule({
           conditions,
           selector: `${root.selector}${key}`,
-          rule: rule[key as keyof typeof rule] as CSSProperties,
+          rule: rule[key as keyof typeof rule] as CSSPropertiesWithVars,
         });
       }
     }

--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -7,9 +7,9 @@ export type CSSVarFunction =
   | `var(--${string})`
   | `var(--${string}, ${string | number})`;
 
-type CSSTypeProperties = PropertiesFallback<string | number>;
+type CSSTypeProperties = PropertiesFallback<number | (string & {})>;
 
-type BasicCSSProperties = {
+export type CSSProperties = {
   [Property in keyof CSSTypeProperties]:
     | CSSTypeProperties[Property]
     | CSSVarFunction
@@ -17,23 +17,27 @@ type BasicCSSProperties = {
 };
 
 export interface CSSKeyframes {
-  [time: string]: BasicCSSProperties;
+  [time: string]: CSSProperties;
 }
 
-export type CSSProperties = BasicCSSProperties & {
+export type CSSPropertiesWithVars = CSSProperties & {
   vars?: {
     [key: string]: string;
   };
 };
 
-type PseudoProperties = { [key in SimplePseudos[number]]?: CSSProperties };
+type PseudoProperties = {
+  [key in SimplePseudos[number]]?: CSSPropertiesWithVars;
+};
 
-type CSSPropertiesAndPseudos = CSSProperties & PseudoProperties;
+type CSSPropertiesAndPseudos = CSSPropertiesWithVars & PseudoProperties;
 
 interface SelectorMap {
-  [selector: string]: CSSProperties &
-    MediaQueries<CSSProperties & FeatureQueries<CSSProperties>> &
-    FeatureQueries<CSSProperties & MediaQueries<CSSProperties>>;
+  [selector: string]: CSSPropertiesWithVars &
+    MediaQueries<
+      CSSPropertiesWithVars & FeatureQueries<CSSPropertiesWithVars>
+    > &
+    FeatureQueries<CSSPropertiesWithVars & MediaQueries<CSSPropertiesWithVars>>;
 }
 
 export interface MediaQueries<StyleType> {
@@ -56,9 +60,9 @@ export type StyleRule = StyleWithSelectors &
   MediaQueries<StyleWithSelectors & FeatureQueries<StyleWithSelectors>> &
   FeatureQueries<StyleWithSelectors & MediaQueries<StyleWithSelectors>>;
 
-export type GlobalStyleRule = CSSProperties &
-  MediaQueries<CSSProperties & FeatureQueries<CSSProperties>> &
-  FeatureQueries<CSSProperties & MediaQueries<CSSProperties>>;
+export type GlobalStyleRule = CSSPropertiesWithVars &
+  MediaQueries<CSSPropertiesWithVars & FeatureQueries<CSSPropertiesWithVars>> &
+  FeatureQueries<CSSPropertiesWithVars & MediaQueries<CSSPropertiesWithVars>>;
 
 export type GlobalFontFaceRule = Omit<AtRule.FontFaceFallback, 'src'> &
   Required<Pick<AtRule.FontFaceFallback, 'src'>>;

--- a/packages/sprinkles/src/index.ts
+++ b/packages/sprinkles/src/index.ts
@@ -1,10 +1,4 @@
-import { style } from '@vanilla-extract/css';
-import type { Contract, MapLeafNodes } from '@vanilla-extract/private';
-import type * as CSS from 'csstype';
-
-export type CSSVarFunction =
-  | `var(--${string})`
-  | `var(--${string}, ${string | number})`;
+import { style, CSSProperties } from '@vanilla-extract/css';
 
 import {
   AtomicStyles,
@@ -21,11 +15,8 @@ interface Condition {
 
 type BaseConditions = { [conditionName: string]: Condition };
 
-type CSSProperties = CSS.Properties<(string & {}) | number>;
-
 type AtomicProperties = {
   [Property in keyof CSSProperties]?:
-    | MapLeafNodes<Contract, CSSVarFunction>
     | Record<string, CSSProperties[Property]>
     | Array<CSSProperties[Property]>;
 };

--- a/packages/sprinkles/src/index.ts
+++ b/packages/sprinkles/src/index.ts
@@ -1,5 +1,10 @@
 import { style } from '@vanilla-extract/css';
+import type { Contract, MapLeafNodes } from '@vanilla-extract/private';
 import type * as CSS from 'csstype';
+
+export type CSSVarFunction =
+  | `var(--${string})`
+  | `var(--${string}, ${string | number})`;
 
 import {
   AtomicStyles,
@@ -20,6 +25,7 @@ type CSSProperties = CSS.Properties<(string & {}) | number>;
 
 type AtomicProperties = {
   [Property in keyof CSSProperties]?:
+    | MapLeafNodes<Contract, CSSVarFunction>
     | Record<string, CSSProperties[Property]>
     | Array<CSSProperties[Property]>;
 };

--- a/tests/E2E/__snapshots__/stylesheets.test.ts.snap
+++ b/tests/E2E/__snapshots__/stylesheets.test.ts.snap
@@ -143,7 +143,37 @@ exports[`Stylesheet sprinkles - webpack should create valid stylesheet 1`] = `
 `;
 
 exports[`Stylesheet themed - esbuild should create valid stylesheet 1`] = `
-"/* vanilla-extract-css-ns:@fixtures/themed/src/shared.css.ts.vanilla.css?source=LnNoYXJlZF9fNGR0ZmVuMCB7CiAgYm94LXNoYWRvdzogMCAwIDVweCByZWQ7Cn0KYm9keSB7CiAgYmFja2dyb3VuZC1jb2xvcjogc2t5Ymx1ZTsKfQ== */
+"/* vanilla-extract-css-ns:@fixtures/themed/src/themes.css.ts.vanilla.css?source=OnJvb3QsIC50aGVtZXNfX2N2dGExNzAgewogIC0tY29sb3JzLWJhY2tncm91bmQtY29sb3JfX2N2dGExNzE6IGJsdWU7CiAgLS1jb2xvcnMtdGV4dF9fY3Z0YTE3Mjogd2hpdGU7CiAgLS1zcGFjZS0xX19jdnRhMTczOiA0cHg7CiAgLS1zcGFjZS0yX19jdnRhMTc0OiA4cHg7CiAgLS1zcGFjZS0zX19jdnRhMTc1OiAxMnB4Owp9Ci50aGVtZXNfX2N2dGExNzYgewogIC0tY29sb3JzLWJhY2tncm91bmQtY29sb3JfX2N2dGExNzE6IGdyZWVuOwogIC0tY29sb3JzLXRleHRfX2N2dGExNzI6IHdoaXRlOwogIC0tc3BhY2UtMV9fY3Z0YTE3MzogOHB4OwogIC0tc3BhY2UtMl9fY3Z0YTE3NDogMTJweDsKICAtLXNwYWNlLTNfX2N2dGExNzU6IDE2cHg7Cn0KLnRoZW1lc19fY3Z0YTE3NyB7CiAgLS1jb2xvcnMtYmFja2dyb3VuZC1jb2xvcl9fY3Z0YTE3MTogcGluazsKICAtLWNvbG9ycy10ZXh0X19jdnRhMTcyOiBwdXJwbGU7CiAgLS1zcGFjZS0xX19jdnRhMTczOiA2cHg7CiAgLS1zcGFjZS0yX19jdnRhMTc0OiAxMnB4OwogIC0tc3BhY2UtM19fY3Z0YTE3NTogMThweDsKfQpAbWVkaWEgc2NyZWVuIGFuZCAobWluLXdpZHRoOiA3NjhweCkgewogIC50aGVtZXNfX2N2dGExNzcgewogICAgLS1jb2xvcnMtYmFja2dyb3VuZC1jb2xvcl9fY3Z0YTE3MTogcHVycGxlOwogICAgLS1jb2xvcnMtdGV4dF9fY3Z0YTE3MjogcGluazsKICB9Cn0= */
+:root,
+.themes__cvta170 {
+  --colors-background-color__cvta171: blue;
+  --colors-text__cvta172: white;
+  --space-1__cvta173: 4px;
+  --space-2__cvta174: 8px;
+  --space-3__cvta175: 12px;
+}
+.themes__cvta176 {
+  --colors-background-color__cvta171: green;
+  --colors-text__cvta172: white;
+  --space-1__cvta173: 8px;
+  --space-2__cvta174: 12px;
+  --space-3__cvta175: 16px;
+}
+.themes__cvta177 {
+  --colors-background-color__cvta171: pink;
+  --colors-text__cvta172: purple;
+  --space-1__cvta173: 6px;
+  --space-2__cvta174: 12px;
+  --space-3__cvta175: 18px;
+}
+@media screen and (min-width: 768px) {
+  .themes__cvta177 {
+    --colors-background-color__cvta171: purple;
+    --colors-text__cvta172: pink;
+  }
+}
+
+/* vanilla-extract-css-ns:@fixtures/themed/src/shared.css.ts.vanilla.css?source=LnNoYXJlZF9fNGR0ZmVuMCB7CiAgYm94LXNoYWRvdzogMCAwIDVweCByZWQ7Cn0KYm9keSB7CiAgYmFja2dyb3VuZC1jb2xvcjogc2t5Ymx1ZTsKfQ== */
 .shared__4dtfen0 {
   box-shadow: 0 0 5px red;
 }
@@ -205,36 +235,6 @@ body {
   }
   .styles__jteyb13 {
     border-radius: 9999px;
-  }
-}
-
-/* vanilla-extract-css-ns:@fixtures/themed/src/themes.css.ts.vanilla.css?source=OnJvb3QsIC50aGVtZXNfX2N2dGExNzAgewogIC0tY29sb3JzLWJhY2tncm91bmQtY29sb3JfX2N2dGExNzE6IGJsdWU7CiAgLS1jb2xvcnMtdGV4dF9fY3Z0YTE3Mjogd2hpdGU7CiAgLS1zcGFjZS0xX19jdnRhMTczOiA0cHg7CiAgLS1zcGFjZS0yX19jdnRhMTc0OiA4cHg7CiAgLS1zcGFjZS0zX19jdnRhMTc1OiAxMnB4Owp9Ci50aGVtZXNfX2N2dGExNzYgewogIC0tY29sb3JzLWJhY2tncm91bmQtY29sb3JfX2N2dGExNzE6IGdyZWVuOwogIC0tY29sb3JzLXRleHRfX2N2dGExNzI6IHdoaXRlOwogIC0tc3BhY2UtMV9fY3Z0YTE3MzogOHB4OwogIC0tc3BhY2UtMl9fY3Z0YTE3NDogMTJweDsKICAtLXNwYWNlLTNfX2N2dGExNzU6IDE2cHg7Cn0KLnRoZW1lc19fY3Z0YTE3NyB7CiAgLS1jb2xvcnMtYmFja2dyb3VuZC1jb2xvcl9fY3Z0YTE3MTogcGluazsKICAtLWNvbG9ycy10ZXh0X19jdnRhMTcyOiBwdXJwbGU7CiAgLS1zcGFjZS0xX19jdnRhMTczOiA2cHg7CiAgLS1zcGFjZS0yX19jdnRhMTc0OiAxMnB4OwogIC0tc3BhY2UtM19fY3Z0YTE3NTogMThweDsKfQpAbWVkaWEgc2NyZWVuIGFuZCAobWluLXdpZHRoOiA3NjhweCkgewogIC50aGVtZXNfX2N2dGExNzcgewogICAgLS1jb2xvcnMtYmFja2dyb3VuZC1jb2xvcl9fY3Z0YTE3MTogcHVycGxlOwogICAgLS1jb2xvcnMtdGV4dF9fY3Z0YTE3MjogcGluazsKICB9Cn0= */
-:root,
-.themes__cvta170 {
-  --colors-background-color__cvta171: blue;
-  --colors-text__cvta172: white;
-  --space-1__cvta173: 4px;
-  --space-2__cvta174: 8px;
-  --space-3__cvta175: 12px;
-}
-.themes__cvta176 {
-  --colors-background-color__cvta171: green;
-  --colors-text__cvta172: white;
-  --space-1__cvta173: 8px;
-  --space-2__cvta174: 12px;
-  --space-3__cvta175: 16px;
-}
-.themes__cvta177 {
-  --colors-background-color__cvta171: pink;
-  --colors-text__cvta172: purple;
-  --space-1__cvta173: 6px;
-  --space-2__cvta174: 12px;
-  --space-3__cvta175: 18px;
-}
-@media screen and (min-width: 768px) {
-  .themes__cvta177 {
-    --colors-background-color__cvta171: purple;
-    --colors-text__cvta172: pink;
   }
 }
 "
@@ -339,11 +339,6 @@ body {
   background-color: lavender;
 }
 
-/* vanilla-extract-css-ns:@fixtures/unused-modules/src/reset/reset.css.ts.vanilla.css?source=LnJlc2V0X18xajc4enRxMCB7CiAgYm94LXNpemluZzogYm9yZGVyLWJveDsKfQ== */
-.reset__1j78ztq0 {
-  box-sizing: border-box;
-}
-
 /* vanilla-extract-css-ns:@fixtures/unused-modules/src/shared/shared.css.ts.vanilla.css?source=Ym9keSB7CiAgYm9yZGVyOiA1cHggc29saWQgYmxhY2s7Cn0KLnNoYXJlZF9fZmJpaGM2MCB7CiAgZGlzcGxheTogZmxleDsKfQ== */
 body {
   border: 5px solid black;
@@ -357,6 +352,11 @@ body {
   height: 100px;
   width: 100px;
   background: green;
+}
+
+/* vanilla-extract-css-ns:@fixtures/unused-modules/src/reset/reset.css.ts.vanilla.css?source=LnJlc2V0X18xajc4enRxMCB7CiAgYm94LXNpemluZzogYm9yZGVyLWJveDsKfQ== */
+.reset__1j78ztq0 {
+  box-sizing: border-box;
 }
 "
 `;

--- a/tests/E2E/__snapshots__/stylesheets.test.ts.snap
+++ b/tests/E2E/__snapshots__/stylesheets.test.ts.snap
@@ -143,37 +143,7 @@ exports[`Stylesheet sprinkles - webpack should create valid stylesheet 1`] = `
 `;
 
 exports[`Stylesheet themed - esbuild should create valid stylesheet 1`] = `
-"/* vanilla-extract-css-ns:@fixtures/themed/src/themes.css.ts.vanilla.css?source=OnJvb3QsIC50aGVtZXNfX2N2dGExNzAgewogIC0tY29sb3JzLWJhY2tncm91bmQtY29sb3JfX2N2dGExNzE6IGJsdWU7CiAgLS1jb2xvcnMtdGV4dF9fY3Z0YTE3Mjogd2hpdGU7CiAgLS1zcGFjZS0xX19jdnRhMTczOiA0cHg7CiAgLS1zcGFjZS0yX19jdnRhMTc0OiA4cHg7CiAgLS1zcGFjZS0zX19jdnRhMTc1OiAxMnB4Owp9Ci50aGVtZXNfX2N2dGExNzYgewogIC0tY29sb3JzLWJhY2tncm91bmQtY29sb3JfX2N2dGExNzE6IGdyZWVuOwogIC0tY29sb3JzLXRleHRfX2N2dGExNzI6IHdoaXRlOwogIC0tc3BhY2UtMV9fY3Z0YTE3MzogOHB4OwogIC0tc3BhY2UtMl9fY3Z0YTE3NDogMTJweDsKICAtLXNwYWNlLTNfX2N2dGExNzU6IDE2cHg7Cn0KLnRoZW1lc19fY3Z0YTE3NyB7CiAgLS1jb2xvcnMtYmFja2dyb3VuZC1jb2xvcl9fY3Z0YTE3MTogcGluazsKICAtLWNvbG9ycy10ZXh0X19jdnRhMTcyOiBwdXJwbGU7CiAgLS1zcGFjZS0xX19jdnRhMTczOiA2cHg7CiAgLS1zcGFjZS0yX19jdnRhMTc0OiAxMnB4OwogIC0tc3BhY2UtM19fY3Z0YTE3NTogMThweDsKfQpAbWVkaWEgc2NyZWVuIGFuZCAobWluLXdpZHRoOiA3NjhweCkgewogIC50aGVtZXNfX2N2dGExNzcgewogICAgLS1jb2xvcnMtYmFja2dyb3VuZC1jb2xvcl9fY3Z0YTE3MTogcHVycGxlOwogICAgLS1jb2xvcnMtdGV4dF9fY3Z0YTE3MjogcGluazsKICB9Cn0= */
-:root,
-.themes__cvta170 {
-  --colors-background-color__cvta171: blue;
-  --colors-text__cvta172: white;
-  --space-1__cvta173: 4px;
-  --space-2__cvta174: 8px;
-  --space-3__cvta175: 12px;
-}
-.themes__cvta176 {
-  --colors-background-color__cvta171: green;
-  --colors-text__cvta172: white;
-  --space-1__cvta173: 8px;
-  --space-2__cvta174: 12px;
-  --space-3__cvta175: 16px;
-}
-.themes__cvta177 {
-  --colors-background-color__cvta171: pink;
-  --colors-text__cvta172: purple;
-  --space-1__cvta173: 6px;
-  --space-2__cvta174: 12px;
-  --space-3__cvta175: 18px;
-}
-@media screen and (min-width: 768px) {
-  .themes__cvta177 {
-    --colors-background-color__cvta171: purple;
-    --colors-text__cvta172: pink;
-  }
-}
-
-/* vanilla-extract-css-ns:@fixtures/themed/src/shared.css.ts.vanilla.css?source=LnNoYXJlZF9fNGR0ZmVuMCB7CiAgYm94LXNoYWRvdzogMCAwIDVweCByZWQ7Cn0KYm9keSB7CiAgYmFja2dyb3VuZC1jb2xvcjogc2t5Ymx1ZTsKfQ== */
+"/* vanilla-extract-css-ns:@fixtures/themed/src/shared.css.ts.vanilla.css?source=LnNoYXJlZF9fNGR0ZmVuMCB7CiAgYm94LXNoYWRvdzogMCAwIDVweCByZWQ7Cn0KYm9keSB7CiAgYmFja2dyb3VuZC1jb2xvcjogc2t5Ymx1ZTsKfQ== */
 .shared__4dtfen0 {
   box-shadow: 0 0 5px red;
 }
@@ -235,6 +205,36 @@ body {
   }
   .styles__jteyb13 {
     border-radius: 9999px;
+  }
+}
+
+/* vanilla-extract-css-ns:@fixtures/themed/src/themes.css.ts.vanilla.css?source=OnJvb3QsIC50aGVtZXNfX2N2dGExNzAgewogIC0tY29sb3JzLWJhY2tncm91bmQtY29sb3JfX2N2dGExNzE6IGJsdWU7CiAgLS1jb2xvcnMtdGV4dF9fY3Z0YTE3Mjogd2hpdGU7CiAgLS1zcGFjZS0xX19jdnRhMTczOiA0cHg7CiAgLS1zcGFjZS0yX19jdnRhMTc0OiA4cHg7CiAgLS1zcGFjZS0zX19jdnRhMTc1OiAxMnB4Owp9Ci50aGVtZXNfX2N2dGExNzYgewogIC0tY29sb3JzLWJhY2tncm91bmQtY29sb3JfX2N2dGExNzE6IGdyZWVuOwogIC0tY29sb3JzLXRleHRfX2N2dGExNzI6IHdoaXRlOwogIC0tc3BhY2UtMV9fY3Z0YTE3MzogOHB4OwogIC0tc3BhY2UtMl9fY3Z0YTE3NDogMTJweDsKICAtLXNwYWNlLTNfX2N2dGExNzU6IDE2cHg7Cn0KLnRoZW1lc19fY3Z0YTE3NyB7CiAgLS1jb2xvcnMtYmFja2dyb3VuZC1jb2xvcl9fY3Z0YTE3MTogcGluazsKICAtLWNvbG9ycy10ZXh0X19jdnRhMTcyOiBwdXJwbGU7CiAgLS1zcGFjZS0xX19jdnRhMTczOiA2cHg7CiAgLS1zcGFjZS0yX19jdnRhMTc0OiAxMnB4OwogIC0tc3BhY2UtM19fY3Z0YTE3NTogMThweDsKfQpAbWVkaWEgc2NyZWVuIGFuZCAobWluLXdpZHRoOiA3NjhweCkgewogIC50aGVtZXNfX2N2dGExNzcgewogICAgLS1jb2xvcnMtYmFja2dyb3VuZC1jb2xvcl9fY3Z0YTE3MTogcHVycGxlOwogICAgLS1jb2xvcnMtdGV4dF9fY3Z0YTE3MjogcGluazsKICB9Cn0= */
+:root,
+.themes__cvta170 {
+  --colors-background-color__cvta171: blue;
+  --colors-text__cvta172: white;
+  --space-1__cvta173: 4px;
+  --space-2__cvta174: 8px;
+  --space-3__cvta175: 12px;
+}
+.themes__cvta176 {
+  --colors-background-color__cvta171: green;
+  --colors-text__cvta172: white;
+  --space-1__cvta173: 8px;
+  --space-2__cvta174: 12px;
+  --space-3__cvta175: 16px;
+}
+.themes__cvta177 {
+  --colors-background-color__cvta171: pink;
+  --colors-text__cvta172: purple;
+  --space-1__cvta173: 6px;
+  --space-2__cvta174: 12px;
+  --space-3__cvta175: 18px;
+}
+@media screen and (min-width: 768px) {
+  .themes__cvta177 {
+    --colors-background-color__cvta171: purple;
+    --colors-text__cvta172: pink;
   }
 }
 "
@@ -339,6 +339,11 @@ body {
   background-color: lavender;
 }
 
+/* vanilla-extract-css-ns:@fixtures/unused-modules/src/reset/reset.css.ts.vanilla.css?source=LnJlc2V0X18xajc4enRxMCB7CiAgYm94LXNpemluZzogYm9yZGVyLWJveDsKfQ== */
+.reset__1j78ztq0 {
+  box-sizing: border-box;
+}
+
 /* vanilla-extract-css-ns:@fixtures/unused-modules/src/shared/shared.css.ts.vanilla.css?source=Ym9keSB7CiAgYm9yZGVyOiA1cHggc29saWQgYmxhY2s7Cn0KLnNoYXJlZF9fZmJpaGM2MCB7CiAgZGlzcGxheTogZmxleDsKfQ== */
 body {
   border: 5px solid black;
@@ -352,11 +357,6 @@ body {
   height: 100px;
   width: 100px;
   background: green;
-}
-
-/* vanilla-extract-css-ns:@fixtures/unused-modules/src/reset/reset.css.ts.vanilla.css?source=LnJlc2V0X18xajc4enRxMCB7CiAgYm94LXNpemluZzogYm9yZGVyLWJveDsKfQ== */
-.reset__1j78ztq0 {
-  box-sizing: border-box;
 }
 "
 `;

--- a/tests/sprinkles/index.css.ts
+++ b/tests/sprinkles/index.css.ts
@@ -1,3 +1,4 @@
+import { createVar } from '@vanilla-extract/css';
 import { createAtomicStyles } from '@vanilla-extract/sprinkles';
 
 const spacing = {
@@ -92,6 +93,7 @@ export const atomicWithPaddingShorthandStyles = createAtomicStyles({
     paddingRight: spacing,
     paddingTop: spacing,
     paddingBottom: spacing,
+    fontWeight: [createVar()],
   },
   shorthands: {
     padding: ['paddingTop', 'paddingBottom', 'paddingLeft', 'paddingRight'],

--- a/tests/sprinkles/sprinkles.test.ts
+++ b/tests/sprinkles/sprinkles.test.ts
@@ -203,7 +203,7 @@ describe('sprinkles', () => {
           padding: 'large',
         }),
       ).toMatchInlineSnapshot(
-        `"sprinkles_paddingTop_small__1kw4bre1q sprinkles_paddingBottom_medium__1kw4bre1u sprinkles_paddingLeft_small__1kw4bre1k sprinkles_paddingRight_small__1kw4bre1n"`,
+        `"sprinkles_paddingTop_small__1kw4bre1r sprinkles_paddingBottom_medium__1kw4bre1v sprinkles_paddingLeft_small__1kw4bre1l sprinkles_paddingRight_small__1kw4bre1o"`,
       );
     });
 
@@ -216,7 +216,7 @@ describe('sprinkles', () => {
           padding: 'large',
         }),
       ).toMatchInlineSnapshot(
-        `"sprinkles_paddingTop_large__1kw4bre1s sprinkles_paddingBottom_large__1kw4bre1v sprinkles_paddingLeft_small__1kw4bre1k sprinkles_paddingRight_small__1kw4bre1n"`,
+        `"sprinkles_paddingTop_large__1kw4bre1t sprinkles_paddingBottom_large__1kw4bre1w sprinkles_paddingLeft_small__1kw4bre1l sprinkles_paddingRight_small__1kw4bre1o"`,
       );
     });
   });


### PR DESCRIPTION
This change makes it possible to pass theme vars from `createThemeContract`/`createTheme` to be passed to atomic styles properties.