### PR TITLE
Compile .css.ts files with ts loader

### DIFF
--- a/.changeset/sweet-turkeys-rhyme.md
+++ b/.changeset/sweet-turkeys-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/esbuild-plugin': patch
+---
+
+Fix errors occurring when using TypeScript in .css.ts files

--- a/fixtures/themed/src/shared.css.ts
+++ b/fixtures/themed/src/shared.css.ts
@@ -1,6 +1,6 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
-export const shadow = style({
+export const shadow: string = style({
   boxShadow: '0 0 5px red',
 });
 

--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -53,6 +53,7 @@ const vanillaExtractFilescopePlugin = (): Plugin => ({
 
         return {
           contents,
+          loader: path.match(/\.(ts|tsx)$/i) ? 'ts' : undefined,
           resolveDir: dirname(path),
         };
       }


### PR DESCRIPTION
[By default](https://esbuild.github.io/content-types/#javascript) esbuild will use the `js` loader for any content returned from an `onLoad` callback.

This change attempts to detect whether the file being loaded ends in `.ts` or `.tsx` and switches to use the ts loader as documented here:

https://esbuild.github.io/content-types/#typescript

Files that are not detected as `.ts` files will use the current default behaviour of using the `js` loader.

**Example error:**
```
> src/App.css.ts:9:5: error: Expected ";" but found "Hello"
    9 │ type Hello = string;
      ╵      ~~~~~
```