### PR TITLE
CSS: Accept number values for theme vars and contracts

### DIFF
--- a/.changeset/green-yaks-rhyme.md
+++ b/.changeset/green-yaks-rhyme.md
@@ -1,0 +1,6 @@
+---
+'@vanilla-extract/css': patch
+'@vanilla-extract/private': patch
+---
+
+Accept number values for theme vars and contracts

--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -109,7 +109,7 @@ export interface Adapter {
 }
 
 export type Tokens = {
-  [key: string]: string | Tokens;
+  [key: string]: number | string | Tokens;
 };
 
 export type ThemeVars<ThemeContract extends Contract> = MapLeafNodes<

--- a/packages/private/src/types.ts
+++ b/packages/private/src/types.ts
@@ -1,5 +1,5 @@
 export type Contract = {
-  [key: string]: string | null | Contract;
+  [key: string]: number | string | null | Contract;
 };
 
 export type MapLeafNodes<Obj, LeafType> = {


### PR DESCRIPTION
This change adds the ability to pass numeric values to theme variables/contracts.