### PR TITLE
Fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ $ npm install @vanilla-extract/css @vanilla-extract/vite-plugin
 2. Add the [Vite](https://vitejs.dev/) plugin to your Vite config.
 
 ```js
-import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
+import vanillaExtractPlugin from '@vanilla-extract/vite-plugin';
 
 // vite.config.js
 export default {


### PR DESCRIPTION
Hi there,

This PR fixes a typo in the Vite plugin section of the README, the plugin is a default export ([reference](https://github.com/seek-oss/vanilla-extract/blob/master/packages/vite-plugin/src/index.ts#L11)).

Kind regards,
Hampus Kraft.