### PR TITLE
Site: Fix missing error underline

### DIFF
--- a/site/src/Code/Code.tsx
+++ b/site/src/Code/Code.tsx
@@ -58,7 +58,7 @@ export default ({
 
     const errorNodes: Array<Element> = [];
     for (const span of Array.from(spans)) {
-      if (span.innerHTML && errorTokens.includes(span.innerHTML)) {
+      if (span.innerHTML && errorTokens.includes(span.innerHTML.trim())) {
         span.classList.add(styles.errorUnderline);
         errorNodes.push(span);
       }


### PR DESCRIPTION
This fixes an issue where the keyword `large` isn't underlined in the hero code snippet anymore.