### PR TITLE
Add processCss callback option for esbuild plugin

### DIFF
--- a/.changeset/curly-bats-allow.md
+++ b/.changeset/curly-bats-allow.md
@@ -1,5 +1,5 @@
 ---
-'@vanilla-extract/esbuild-plugin': patch
+'@vanilla-extract/esbuild-plugin': minor
 ---
 
 Add `processCss` plugin option to allow further processing of css while bundling.

--- a/.changeset/curly-bats-allow.md
+++ b/.changeset/curly-bats-allow.md
@@ -2,7 +2,7 @@
 '@vanilla-extract/esbuild-plugin': minor
 ---
 
-Add `processCss` plugin option to allow further processing of css while bundling.
+Add `processCss` plugin option to allow further processing of CSS while bundling.
 
 **Example for postcss with autoprefixer:**
 

--- a/.changeset/curly-bats-allow.md
+++ b/.changeset/curly-bats-allow.md
@@ -1,0 +1,28 @@
+---
+'@vanilla-extract/esbuild-plugin': patch
+---
+
+Add `processCss` plugin option to allow further processing of css while bundling.
+
+**Example for postcss with autoprefixer:**
+
+```js
+const { vanillaExtractPlugin } = require('@vanilla-extract/esbuild-plugin');
+const postcss = require('postcss');
+const autoprefixer = require('autoprefixer');
+
+require('esbuild').build({
+  entryPoints: ['app.ts'],
+  bundle: true,
+  plugins: [vanillaExtractPlugin({
+
+    processCss: async (css) => {
+      return (await postcss([autoprefixer])
+        .process(css, { from: undefined /* suppress source map warning */ })
+      ).css
+    }
+
+  })],
+  outfile: 'out.js',
+}).catch(() => process.exit(1))
+```

--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -20,7 +20,7 @@ export function vanillaExtractPlugin({
   outputCss,
   externals = [],
   runtime = false,
-  processCss
+  processCss,
 }: VanillaExtractPluginOptions = {}): Plugin {
   if (runtime) {
     // If using runtime CSS then just apply fileScopes to code

--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -14,11 +14,13 @@ interface VanillaExtractPluginOptions {
   outputCss?: boolean;
   externals?: Array<string>;
   runtime?: boolean;
+  processCss?: (css: string) => Promise<string>;
 }
 export function vanillaExtractPlugin({
   outputCss,
   externals = [],
   runtime = false,
+  processCss
 }: VanillaExtractPluginOptions = {}): Plugin {
   if (runtime) {
     // If using runtime CSS then just apply fileScopes to code
@@ -37,8 +39,12 @@ export function vanillaExtractPlugin({
 
       build.onLoad(
         { filter: /.*/, namespace: vanillaCssNamespace },
-        ({ path }) => {
-          const { source } = getSourceFromVirtualCssFile(path);
+        async ({ path }) => {
+          let { source } = getSourceFromVirtualCssFile(path);
+
+          if (typeof processCss === 'function') {
+            source = await processCss(source);
+          }
 
           return {
             contents: source,


### PR DESCRIPTION
Add `processCss` plugin option to allow further processing of css while bundling.

**Example for postcss with autoprefixer:**

```js
// build.js
const { vanillaExtractPlugin } = require('@vanilla-extract/esbuild-plugin');
const postcss = require('postcss');
const autoprefixer = require('autoprefixer');

require('esbuild').build({
  entryPoints: ['app.ts'],
  bundle: true,
  plugins: [vanillaExtractPlugin({

    processCss: async (css) => {
      return (await postcss([autoprefixer])
        .process(css, { from: undefined /* suppress source map warning */ })
      ).css
    }

  })],
  outfile: 'out.js',
}).catch(() => process.exit(1))
```