### PR TITLE
Docs: Add note that `globalStyle()` only supports single class name

### DIFF
--- a/.changeset/light-shrimps-check.md
+++ b/.changeset/light-shrimps-check.md
@@ -1,0 +1,6 @@
+---
+'site': patch
+'@vanilla-extract/css': patch
+---
+
+Add docs note that `globalStyle()` only supports single class name expressions in selector templates.

--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ globalStyle(`${parentClass} > a`, {
   color: 'pink'
 });
 ```
+> Please note: In this example parentClass must be a single class name - as is returned by `style()`.  Functions that may return multiple class names, such as `composeStyles()` and Sprinkle's `atoms()`, are not compatible with `globalStyle()`. 
 
 ### createTheme
 

--- a/site/docs/styling-api.md
+++ b/site/docs/styling-api.md
@@ -144,7 +144,8 @@ globalStyle(`${parentClass} > a`, {
   color: 'pink'
 });
 ```
-> Please note: In this example parentClass must be a single class name - as is returned by `style()`.  Functions that may return multiple class names, such as `composeStyles()` and Sprinkle's `atoms()`, are not compatible with `globalStyle()`. 
+
+> Please note: In this example parentClass must be a single class name - as is returned by `style()`. Functions that may return multiple class names, such as `composeStyles()` and Sprinkle's `atoms()`, are not compatible with `globalStyle()`.
 
 ## createTheme
 

--- a/site/docs/styling-api.md
+++ b/site/docs/styling-api.md
@@ -144,6 +144,7 @@ globalStyle(`${parentClass} > a`, {
   color: 'pink'
 });
 ```
+> Please note: In this example parentClass must be a single class name - as is returned by `style()`.  Functions that may return multiple class names, such as `composeStyles()` and Sprinkle's `atoms()`, are not compatible with `globalStyle()`. 
 
 ## createTheme
 


### PR DESCRIPTION
Possibly suitable to address this issue https://github.com/seek-oss/vanilla-extract/issues/191