### PR TITLE
Add note about extracting vendor chunk with webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,29 @@ module.exports = {
   ```
 </details>
 
+<details>
+  <summary>If you extract vendor chunk using cacheGroups, make sure you exclude virtual-resource-loader and @vanilla-extract.</summary>
+
+  <br/>
+  For example:
+  
+  ```js
+  module.exports = {
+    optimization: {
+      splitChunks: {
+        cacheGroups: {
+          vendor: {
+            name: 'vendor',
+            chunks: 'initial',
+            test: /node_modules\/(?!(virtual-resource-loader|@vanilla-extract))/,
+          }
+        }
+      }
+    }
+  };
+  ```
+</details>
+
 ### esbuild
 
 1. Install the dependencies.


### PR DESCRIPTION
I struggled to make vanilla-extract work with webpack because I had a configuration that extracts `vendor.js`, but I never included `vendor.css`. Also, extracting all vanilla-extract CSS into `vendor.css` doesn't make any sense,