### PR TITLE
Resolve parent packageInfo when using with monorepos

### DIFF
--- a/.changeset/eight-tables-repair.md
+++ b/.changeset/eight-tables-repair.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/integration': minor
+---
+
+Improved support for resolving package info in monorepos

--- a/packages/integration/src/compile.ts
+++ b/packages/integration/src/compile.ts
@@ -9,9 +9,8 @@ import { getPackageInfo } from './packageInfo';
 export const vanillaExtractFilescopePlugin = (): Plugin => ({
   name: 'vanilla-extract-filescope',
   setup(build) {
-    const packageInfo = getPackageInfo(build.initialOptions.absWorkingDir);
-
     build.onLoad({ filter: cssFileFilter }, async ({ path }) => {
+      const packageInfo = getPackageInfo(path);
       const originalSource = await fs.readFile(path, 'utf-8');
 
       if (originalSource.indexOf('@vanilla-extract/css/fileScope') === -1) {


### PR DESCRIPTION
When resolving styles from a different package in a monorepo, the `cwd` package info was being used instead of the package info relative to the styles being imported.

Below is just a simple structure example of the setup I am having issues with. When changing the packageInfo to resolve to the parent package.json relative to the styles being imported, this fixes the issue since. The `id` being passed to the `resolveId` and the `load` functions are now the same (in the Vite plugin).

```
packages
	@package/styles
		sprinkles.css.ts
site
	pages
		index.tsx
	vite.config.ts
```
