### PR TITLE
Add TypeScript transformer

### DIFF
--- a/.changeset/serious-masks-kiss.md
+++ b/.changeset/serious-masks-kiss.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/typescript-transformer': major
+---
+
+Add TypeScript transformer for use with projects that use TypeScript instead of Babel for transpilation

--- a/packages/typescript-transformer/CHANGELOG.md
+++ b/packages/typescript-transformer/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @vanilla-extract/typescript-transformer

--- a/packages/typescript-transformer/package.json
+++ b/packages/typescript-transformer/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@vanilla-extract/typescript-transformer",
+  "version": "0.1.0",
+  "description": "Zero-runtime Stylesheets-in-TypeScript",
+  "main": "dist/vanilla-extract-typescript-transformer.cjs.js",
+  "module": "dist/vanilla-extract-typescript-transformer.esm.js",
+  "preconstruct": {
+    "entrypoints": [
+      "index.ts"
+    ]
+  },
+  "files": [
+    "/dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seek-oss/vanilla-extract.git",
+    "directory": "packages/typescript-transformer"
+  },
+  "author": "SEEK",
+  "license": "MIT",
+  "dependencies": {
+    "@vanilla-extract/integration": "^1.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^4.1.3"
+  },
+  "peerDependencies": {
+    "typescript": ">=4.1.3"
+  }
+}

--- a/packages/typescript-transformer/src/index.test.ts
+++ b/packages/typescript-transformer/src/index.test.ts
@@ -1,0 +1,615 @@
+import * as ts from 'typescript';
+import transformerFactory from './';
+
+const printer = ts.createPrinter();
+
+// a simplified transformation context that provides just enough of the API to run the test quickly
+const createTransformationContextMock = () => {
+  let lexicalEnvironmentFlags: any = undefined;
+  const mockedTransformationContext: Partial<ts.TransformationContext> & {
+    cwd: string;
+    setLexicalEnvironmentFlags(flags: any): void;
+    getLexicalEnvironmentFlags(): any;
+  } = {
+    cwd: __dirname,
+    factory: ts.factory,
+    startLexicalEnvironment() {},
+    endLexicalEnvironment(): ts.Statement[] | undefined {
+      return undefined;
+    },
+    suspendLexicalEnvironment() {},
+    resumeLexicalEnvironment() {},
+    setLexicalEnvironmentFlags(flags: any) {
+      lexicalEnvironmentFlags = flags;
+    },
+    getLexicalEnvironmentFlags() {
+      return lexicalEnvironmentFlags;
+    },
+  };
+  return mockedTransformationContext as ts.TransformationContext;
+};
+
+const transform = (source: string, filename = 'dir/mockFilename.css.ts') => {
+  const sourceFile = ts.createSourceFile(
+    filename,
+    source,
+    ts.ScriptTarget.ESNext,
+    true,
+  );
+
+  const context = createTransformationContextMock();
+  const transformedSourceFile = transformerFactory(context)(sourceFile);
+
+  const transformedSourceText = printer.printFile(transformedSourceFile);
+
+  return transformedSourceText;
+};
+
+describe('typescript transformer', () => {
+  it('should handle style assigned to const', () => {
+    const source = `
+      import { style } from '@vanilla-extract/css';
+
+      const one = style({
+          zIndex: 2
+      });`;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { style } from '@vanilla-extract/css';
+      const one = style({
+          zIndex: 2
+      }, \\"one\\");
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should handle styleVariants assigned to const', () => {
+    const source = `
+      import { styleVariants } from '@vanilla-extract/css';
+
+      const colors = styleVariants({
+          red: { color: 'red' }
+      });
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { styleVariants } from '@vanilla-extract/css';
+      const colors = styleVariants({
+          red: { color: 'red' }
+      }, \\"colors\\");
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should handle styleVariants with mapper assigned to const', () => {
+    const source = `
+      import { styleVariants } from '@vanilla-extract/css';
+
+      const colors = styleVariants({
+          red: 'red'
+      }, (color) => ({ color }));
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { styleVariants } from '@vanilla-extract/css';
+      const colors = styleVariants({
+          red: 'red'
+      }, (color) => ({ color }), \\"colors\\");
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should handle style assigned to default export', () => {
+    const source = `
+      import { style } from '@vanilla-extract/css';
+
+      export default style({
+          zIndex: 2,
+      });
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { style } from '@vanilla-extract/css';
+      export default style({
+          zIndex: 2,
+      }, \\"default\\");
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should handle style assigned to object property', () => {
+    const source = `
+      import { style } from '@vanilla-extract/css';
+
+      const test = {
+          one: {
+              two: style({
+                zIndex: 2,
+              })
+          }
+      };
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { style } from '@vanilla-extract/css';
+      const test = {
+          one: {
+              two: style({
+                  zIndex: 2,
+              }, \\"test_one_two\\")
+          }
+      };
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should handle style returned from an arrow function', () => {
+    const source = `
+      import { style } from '@vanilla-extract/css';
+
+      const test = () => {
+          return style({
+              color: 'red'
+          });
+      };
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { style } from '@vanilla-extract/css';
+      const test = () => {
+          return style({
+              color: 'red'
+          }, \\"test\\");
+      };
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should handle style returned implicitly from an arrow function', () => {
+    const source = `
+      import { style } from '@vanilla-extract/css';
+
+      const test = () => style({
+          color: 'red'
+      });
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { style } from '@vanilla-extract/css';
+      const test = () => style({
+          color: 'red'
+      }, \\"test\\");
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should handle style returned from a function', () => {
+    const source = `
+      import { style } from '@vanilla-extract/css';
+
+      function test() {
+          return style({
+              color: 'red'
+          });
+      }
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { style } from '@vanilla-extract/css';
+      function test() {
+          return style({
+              color: 'red'
+          }, \\"test\\");
+      }
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should handle globalStyle', () => {
+    const source = `
+      import { globalStyle } from '@vanilla-extract/css';
+
+      globalStyle('html, body', { margin: 0 });
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { globalStyle } from '@vanilla-extract/css';
+      globalStyle('html, body', { margin: 0 });
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should handle createVar assigned to const', () => {
+    const source = `
+      import { createVar } from '@vanilla-extract/css';
+
+      const myVar = createVar();
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { createVar } from '@vanilla-extract/css';
+      const myVar = createVar(\\"myVar\\");
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should handle fontFace assigned to const', () => {
+    const source = `
+      import { fontFace } from '@vanilla-extract/css';
+
+      const myFont = fontFace({
+          src: 'local("Comic Sans MS")'
+      });
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { fontFace } from '@vanilla-extract/css';
+      const myFont = fontFace({
+          src: 'local(\\"Comic Sans MS\\")'
+      }, \\"myFont\\");
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should handle globalFontFace', () => {
+    const source = `
+      import { globalFontFace } from '@vanilla-extract/css';
+
+      globalFontFace('myFont', {
+          src: 'local("Comic Sans MS")'
+      });
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { globalFontFace } from '@vanilla-extract/css';
+      globalFontFace('myFont', {
+          src: 'local(\\"Comic Sans MS\\")'
+      });
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should handle keyframes assigned to const', () => {
+    const source = `
+      import { keyframes } from '@vanilla-extract/css';
+
+      const myAnimation = keyframes({
+          from: { transform: 'rotate(0deg)' },
+          to: { transform: 'rotate(360deg)' }
+      });
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { keyframes } from '@vanilla-extract/css';
+      const myAnimation = keyframes({
+          from: { transform: 'rotate(0deg)' },
+          to: { transform: 'rotate(360deg)' }
+      }, \\"myAnimation\\");
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should handle global keyframes', () => {
+    const source = `
+      import { globalKeyframes } from '@vanilla-extract/css';
+
+      globalKeyframes('myKeyframes', {
+          from: { transform: 'rotate(0deg)' },
+          to: { transform: 'rotate(360deg)' }
+      });
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { globalKeyframes } from '@vanilla-extract/css';
+      globalKeyframes('myKeyframes', {
+          from: { transform: 'rotate(0deg)' },
+          to: { transform: 'rotate(360deg)' }
+      });
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should handle createTheme assigned to const', () => {
+    const source = `
+      import { createTheme } from '@vanilla-extract/css';
+
+      const darkTheme = createTheme({}, {});
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { createTheme } from '@vanilla-extract/css';
+      const darkTheme = createTheme({}, {}, \\"darkTheme\\");
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should handle createTheme using destructuring', () => {
+    const source = `
+      import { createTheme } from '@vanilla-extract/css';
+
+      const [theme, vars] = createTheme({}, {});
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { createTheme } from '@vanilla-extract/css';
+      const [theme, vars] = createTheme({}, {}, \\"theme\\");
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should handle createGlobalTheme', () => {
+    const source = `
+      import { createGlobalTheme } from '@vanilla-extract/css';
+
+      const vars = createGlobalTheme(':root', { foo: 'bar' });
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { createGlobalTheme } from '@vanilla-extract/css';
+      const vars = createGlobalTheme(':root', { foo: 'bar' });
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should handle createThemeContract', () => {
+    const source = `
+      import { createThemeContract } from '@vanilla-extract/css';
+
+      const vars = createThemeContract({
+          foo: 'bar'
+      });
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { createThemeContract } from '@vanilla-extract/css';
+      const vars = createThemeContract({
+          foo: 'bar'
+      });
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should ignore functions that already supply a debug name', () => {
+    const source = `
+      import { style, styleVariants } from '@vanilla-extract/css';
+
+      const three = style({
+          testStyle: {
+              zIndex: 2
+          }
+      }, 'myDebugValue');
+
+      const four = styleVariants({
+          red: { color: 'red' }
+      }, 'myDebugValue');
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { style, styleVariants } from '@vanilla-extract/css';
+      const three = style({
+          testStyle: {
+              zIndex: 2
+          }
+      }, 'myDebugValue');
+      const four = styleVariants({
+          red: { color: 'red' }
+      }, 'myDebugValue', \\"four\\");
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should only apply debug ids to functions imported from the relevant package', () => {
+    const source = `
+      import { style } from 'some-other-package';
+
+      const three = style({
+          zIndex: 2  
+      });
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { style } from 'some-other-package';
+      const three = style({
+          zIndex: 2
+      });
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should only apply to .css.ts files', () => {
+    const source = `
+      import { style } from '@vanilla-extract/css';
+
+      const three = style({
+          zIndex: 2  
+      });
+    `;
+
+    expect(transform(source, './dir/mockFilename.ts')).toMatchInlineSnapshot(`
+      "import { style } from '@vanilla-extract/css';
+      const three = style({
+          zIndex: 2
+      });
+      "
+    `);
+  });
+
+  it('should ignore files that already have filescope information', () => {
+    const source = `
+      import { setFileScope, endFileScope } from "@vanilla-extract/css/fileScope";
+      setFileScope('src/dir/someFileName.css.ts', 'some-package');
+      import { style } from '@vanilla-extract/css';
+      const three = style({
+          zIndex: 2  
+      });
+      endFileScope();
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import { setFileScope, endFileScope } from \\"@vanilla-extract/css/fileScope\\";
+      setFileScope('src/dir/someFileName.css.ts', 'some-package');
+      import { style } from '@vanilla-extract/css';
+      const three = style({
+          zIndex: 2
+      });
+      endFileScope();
+      "
+    `);
+  });
+
+  it('should handle renaming imports', () => {
+    const source = `
+      import { style as specialStyle } from '@vanilla-extract/css';
+
+      const four = specialStyle({
+          zIndex: 2
+      });
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { style as specialStyle } from '@vanilla-extract/css';
+      const four = specialStyle({
+          zIndex: 2
+      }, \\"four\\");
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should handle anonymous style in arrays', () => {
+    const source = `
+      import { style } from '@vanilla-extract/css';
+
+      export const height = [
+          style({
+             zIndex: 2
+          })
+      ];
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { style } from '@vanilla-extract/css';
+      export const height = [
+          style({
+              zIndex: 2
+          }, \\"height\\")
+      ];
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should handle object key with anonymous style in arrays', () => {
+    const source = `
+      import { style } from '@vanilla-extract/css';
+
+      export const height = {
+          full: [
+              style({
+                  zIndex: 2
+              })
+          ]
+      };
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import { style } from '@vanilla-extract/css';
+      export const height = {
+          full: [
+              style({
+                  zIndex: 2
+              }, \\"height_full\\")
+          ]
+      };
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+
+  it('should handle namespace imports', () => {
+    const source = `
+      import * as css from '@vanilla-extract/css';
+
+      const one = css.style({
+          zIndex: 2
+      });
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from \\"@vanilla-extract/css/fileScope\\";
+      __vanilla_filescope__.setFileScope(\\"dir/mockFilename.css.ts\\", \\"@vanilla-extract/typescript-transformer\\");
+      import * as css from '@vanilla-extract/css';
+      const one = css.style({
+          zIndex: 2
+      }, \\"one\\");
+      __vanilla_filescope__.endFileScope();
+      "
+    `);
+  });
+});

--- a/packages/typescript-transformer/src/index.ts
+++ b/packages/typescript-transformer/src/index.ts
@@ -1,0 +1,286 @@
+import * as ts from 'typescript';
+import { dirname } from 'path';
+import { getPackageInfo } from '@vanilla-extract/integration';
+
+const packageIdentifier = '@vanilla-extract/css';
+const fileScopePackageIdentifier = '@vanilla-extract/css/fileScope';
+const fileScopeLocalIdentifier = '__vanilla_filescope__';
+
+const factory = ts.factory;
+
+const buildSetFileScopeESMStatements = (
+  filePath: string,
+  packageName: string,
+): ts.Statement[] => [
+  factory.createImportDeclaration(
+    undefined,
+    undefined,
+    factory.createImportClause(
+      false,
+      undefined,
+      factory.createNamespaceImport(
+        factory.createIdentifier(fileScopeLocalIdentifier),
+      ),
+    ),
+    factory.createStringLiteral(fileScopePackageIdentifier),
+  ),
+  factory.createExpressionStatement(
+    factory.createCallExpression(
+      factory.createPropertyAccessExpression(
+        factory.createIdentifier(fileScopeLocalIdentifier),
+        factory.createIdentifier('setFileScope'),
+      ),
+      undefined,
+      [
+        factory.createStringLiteral(filePath),
+        factory.createStringLiteral(packageName),
+      ],
+    ),
+  ),
+];
+
+const endFileScope = factory.createExpressionStatement(
+  factory.createCallExpression(
+    factory.createPropertyAccessExpression(
+      factory.createIdentifier(fileScopeLocalIdentifier),
+      factory.createIdentifier('endFileScope'),
+    ),
+    undefined,
+    [],
+  ),
+);
+
+const debuggableFunctionConfig = {
+  style: {
+    maxParams: 2,
+  },
+  createTheme: {
+    maxParams: 3,
+  },
+  styleVariants: {
+    maxParams: 3,
+  },
+  fontFace: {
+    maxParams: 2,
+  },
+  keyframes: {
+    maxParams: 2,
+  },
+  createVar: {
+    maxParams: 1,
+  },
+};
+
+const extractName = (node: ts.Node) => {
+  if (
+    (ts.isPropertyDeclaration(node) || ts.isPropertyAssignment(node)) &&
+    ts.isIdentifier(node.name)
+  ) {
+    return node.name.text;
+  } else if (
+    (ts.isVariableDeclaration(node) || ts.isFunctionDeclaration(node)) &&
+    node.name &&
+    ts.isIdentifier(node.name)
+  ) {
+    return node.name.text;
+  } else if (
+    ts.isExportAssignment(node) &&
+    node.getChildren().find((c) => c.kind === ts.SyntaxKind.DefaultKeyword)
+  ) {
+    // export default ...
+    return 'default';
+  } else if (
+    ts.isVariableDeclaration(node) &&
+    ts.isArrayBindingPattern(node.name) &&
+    node.name.elements.length &&
+    ts.isBindingElement(node.name.elements[0]) &&
+    ts.isIdentifier(node.name.elements[0].name)
+  ) {
+    // const [name] = ...
+    return node.name.elements[0].name.text;
+  }
+};
+
+const getDebugId = (path: ts.Node) => {
+  const { parent } = path;
+
+  if (
+    ts.isPropertyDeclaration(parent) ||
+    ts.isPropertyAssignment(parent) ||
+    ts.isReturnStatement(parent) ||
+    ts.isArrowFunction(parent) ||
+    ts.isArrayLiteralExpression(parent) ||
+    ts.isSpreadElement(parent)
+  ) {
+    const names: Array<string> = [];
+
+    let currentParent = path;
+    while (currentParent) {
+      const name = extractName(currentParent);
+      if (name) {
+        names.unshift(name);
+      }
+      currentParent = currentParent.parent;
+    }
+    return names.join('_');
+  } else {
+    return extractName(parent);
+  }
+};
+
+const transformer = (
+  context: ts.TransformationContext & { cwd?: string },
+): ts.Transformer<ts.SourceFile> => {
+  const { cwd } = context;
+  return (sourceFile) => {
+    const isCssFile = /\.css\.(js|ts|jsx|tsx)$/.test(sourceFile.fileName);
+    if (!isCssFile) {
+      // skip non .css. vanilla files
+      return sourceFile;
+    }
+
+    for (const statement of sourceFile.statements) {
+      if (
+        ts.isImportDeclaration(statement) &&
+        ts.isStringLiteral(statement.moduleSpecifier) &&
+        statement.moduleSpecifier.text === fileScopePackageIdentifier
+      ) {
+        // already transformed
+        return sourceFile;
+      }
+    }
+
+    const packageInfo = getPackageInfo(cwd ?? dirname(sourceFile.fileName));
+    if (!packageInfo.name) {
+      throw new Error(
+        `Closest package.json (${packageInfo.path}) must specify name`,
+      );
+    }
+
+    const vanillaNamespaceImports = new Set<string>();
+    const vanillaNamedImports = new Set<string>();
+    const vanillaAliasedImports = new Map<string, string>();
+
+    // gather up the imported vanilla-extract functions, including if there's a namespace import of the package
+    for (let statement of sourceFile.statements) {
+      if (ts.isImportDeclaration(statement)) {
+        const { moduleSpecifier } = statement;
+        if (
+          ts.isStringLiteral(moduleSpecifier) &&
+          moduleSpecifier.text === packageIdentifier
+        ) {
+          const namedBindings = statement.importClause?.namedBindings;
+          if (namedBindings) {
+            if (ts.isNamedImports(namedBindings)) {
+              // import {style} from ...
+              for (const namedImport of namedBindings.elements) {
+                if (namedImport.propertyName) {
+                  // import {propertyName as name} from ...
+                  const importedFunctionName = namedImport.propertyName.text;
+                  vanillaAliasedImports.set(
+                    namedImport.name.text,
+                    importedFunctionName,
+                  );
+                  vanillaNamedImports.add(importedFunctionName);
+                } else {
+                  vanillaNamedImports.add(namedImport.name.text);
+                }
+              }
+            } else if (ts.isNamespaceImport(namedBindings)) {
+              // import * as css from ...
+              vanillaNamespaceImports.add(namedBindings.name.text);
+              // meaning we should consider all functions with debug idents as targets for transformation
+              for (const functionNameWithDebugIdent of Object.keys(
+                debuggableFunctionConfig,
+              )) {
+                vanillaNamedImports.add(functionNameWithDebugIdent);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Adds the debug ident for any calls to the vanilla api where the user hasn't specified on already
+    const updateCallExpressionWithDebugIdent = (
+      node: ts.CallExpression,
+      functionIdentifier: ts.Identifier,
+    ): ts.CallExpression | undefined => {
+      const functionName = functionIdentifier.text;
+      const importedName =
+        vanillaAliasedImports.get(functionName) ?? functionName;
+      if (vanillaNamedImports.has(importedName)) {
+        if (importedName in debuggableFunctionConfig) {
+          if (
+            node.arguments.length <
+            debuggableFunctionConfig[
+              importedName as keyof typeof debuggableFunctionConfig
+            ].maxParams
+          ) {
+            const debugIdent = getDebugId(node);
+            if (debugIdent) {
+              const { typeArguments } = node;
+              return ts.factory.updateCallExpression(
+                node,
+                node.expression,
+                typeArguments,
+                [...node.arguments, factory.createStringLiteral(debugIdent)],
+              );
+            }
+          }
+        }
+      }
+    };
+
+    // recursively visits the specified node, updating call expressions as needed
+    const addDebugIdentVisitor = (node: ts.Node): ts.Node => {
+      if (ts.isCallExpression(node)) {
+        const { expression } = node;
+        if (ts.isIdentifier(expression)) {
+          const updatedCallExpression = updateCallExpressionWithDebugIdent(
+            node,
+            expression,
+          );
+          if (updatedCallExpression) {
+            return updatedCallExpression;
+          }
+        } else if (ts.isPropertyAccessExpression(expression)) {
+          // check for namespace use
+          if (
+            ts.isIdentifier(expression.expression) &&
+            vanillaNamespaceImports.has(expression.expression.text)
+          ) {
+            // first part of the property access is the imported vanilla.extract, e.g. `css.`
+            if (ts.isIdentifier(expression.name)) {
+              // and an identifier follows as the property being accessed, e.g `css.style`
+              const updatedCallExpression = updateCallExpressionWithDebugIdent(
+                node,
+                expression.name,
+              );
+              if (updatedCallExpression) {
+                return updatedCallExpression;
+              }
+            }
+          }
+        }
+      }
+      return ts.visitEachChild(
+        node,
+        addDebugIdentVisitor,
+        context as ts.TransformationContext,
+      );
+    };
+
+    const statementsWithDebugIdent = sourceFile.statements.map((statement) =>
+      ts.visitNode(statement, addDebugIdentVisitor),
+    );
+
+    return context.factory.updateSourceFile(sourceFile, [
+      ...buildSetFileScopeESMStatements(sourceFile.fileName, packageInfo.name),
+      ...statementsWithDebugIdent,
+      endFileScope,
+    ]);
+  };
+};
+
+export default transformer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3258,6 +3258,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@vanilla-extract/typescript-transformer@workspace:packages/typescript-transformer":
+  version: 0.0.0-use.local
+  resolution: "@vanilla-extract/typescript-transformer@workspace:packages/typescript-transformer"
+  dependencies:
+    "@vanilla-extract/integration": ^1.0.0
+    typescript: ^4.1.3
+  peerDependencies:
+    typescript: ">=4.1.3"
+  languageName: unknown
+  linkType: soft
+
 "@vanilla-extract/vite-plugin@*, @vanilla-extract/vite-plugin@workspace:packages/vite-plugin":
   version: 0.0.0-use.local
   resolution: "@vanilla-extract/vite-plugin@workspace:packages/vite-plugin"


### PR DESCRIPTION
Adds a TypeScript transformer for use with projects that use TypeScript instead of Babel for transpilation.

The implementation and tests are based on the babel-plugin with the only exception that require statements are currently not supported.

As for the docs at https://vanilla-extract.style/documentation/setup/ would be happy to contribute to that as well, but wanted to get input from the project maintainers beforehand. One option is to split the current "Webpack" section into separate "Webpack with Babel plugin" and "Webpack with TypeScript transformation" sections.