### PR TITLE
Sprinkles: Export ResponsiveArray types

### DIFF
--- a/.changeset/ninety-impalas-stare.md
+++ b/.changeset/ninety-impalas-stare.md
@@ -1,0 +1,5 @@
+---
+"@vanilla-extract/sprinkles": patch
+---
+
+Fix `Exported variable 'Box' has or is using name 'ResponsiveArray' from external module` error ([#250](https://github.com/seek-oss/vanilla-extract/issues/250))

--- a/packages/sprinkles/src/types.ts
+++ b/packages/sprinkles/src/types.ts
@@ -1,10 +1,10 @@
-interface ResponsiveArray<Length extends number, Value>
+export interface ResponsiveArray<Length extends number, Value>
   extends ReadonlyArray<Value> {
   0: Value;
   length: Length;
 }
 
-interface RequiredResponsiveArray<Length extends number, Value>
+export interface RequiredResponsiveArray<Length extends number, Value>
   extends ReadonlyArray<Value> {
   0: Exclude<Value, null>;
   length: Length;


### PR DESCRIPTION
Fixes #250

I'm not sure this is correct, but in case you think the issue is valid and exporting is an ok solution, here's the fix.