### PR TITLE
Remove webpack-plugin compiler cache

### DIFF
--- a/.changeset/strong-coats-float.md
+++ b/.changeset/strong-coats-float.md
@@ -2,4 +2,4 @@
 '@vanilla-extract/webpack-plugin': patch
 ---
 
-Remove compiler cache
+Remove unused compiler cache

--- a/.changeset/strong-coats-float.md
+++ b/.changeset/strong-coats-float.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/webpack-plugin': patch
+---
+
+Remove compiler cache

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -90,10 +90,6 @@ export class VanillaExtractPlugin {
       Boolean(compiler.webpack && compiler.webpack.version),
     );
 
-    compiler.hooks.watchRun.tap(pluginName, () => {
-      this.childCompiler.clearCache();
-    });
-
     if (!compiler.parentCompilation && !this.allowRuntime) {
       compiler.hooks.compilation.tap(pluginName, (compilation) => {
         compilation.hooks.afterOptimizeModules.tap(pluginName, (modules) => {


### PR DESCRIPTION
Since removing child compilations within child compilations the compiler cache no longer gets used. 