### PR TITLE
vite-plugin: fix addWatchFiles call

### DIFF
--- a/.changeset/stupid-news-work.md
+++ b/.changeset/stupid-news-work.md
@@ -1,0 +1,5 @@
+---
+"@vanilla-extract/vite-plugin": patch
+---
+
+Fix watching of modules imported by `.css.ts` files

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -48,7 +48,7 @@ export function vanillaExtractPlugin(): Plugin {
           cwd: config.root,
         });
 
-        for (const file in watchFiles) {
+        for (const file of watchFiles) {
           this.addWatchFile(file);
         }
 


### PR DESCRIPTION
Should be iterating over the array values instead of indices.

Found out about this when testing the fix for https://github.com/vitejs/vite/issues/3216