### PR TITLE
Remove `composeStyles` from readme TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ Want to work at a higher level while maximising style re-use? Check out  🍨 [S
   - [style](#style)
   - [styleVariants](#stylevariants)
   - [globalStyle](#globalstyle)
-  - [composeStyles](#composestyles)
   - [createTheme](#createtheme)
   - [createGlobalTheme](#createglobaltheme)
   - [createThemeContract](#createthemecontract)


### PR DESCRIPTION
Remove reference to deprecated function composeStyles from table of contents.