### PR TITLE
Use `transform` property in docs instead of `rotate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,8 +912,8 @@ Creates a locally scoped set of keyframes.
 import { keyframes, style } from '@vanilla-extract/css';
 
 const rotate = keyframes({
-  '0%': { rotate: '0deg' },
-  '100%': { rotate: '360deg' },
+  '0%': { transform: 'rotate(0deg)' },
+  '100%': { transform: 'rotate(360deg)' }
 });
 
 export const animated = style({
@@ -929,8 +929,8 @@ Creates a globally scoped set of keyframes.
 import { globalKeyframes, style } from '@vanilla-extract/css';
 
 globalKeyframes('rotate', {
-  '0%': { rotate: '0deg' },
-  '100%': { rotate: '360deg' },
+  '0%': { transform: 'rotate(0deg)' },
+  '100%': { transform: 'rotate(360deg)' }
 });
 
 export const animated = style({

--- a/site/docs/styling-api.md
+++ b/site/docs/styling-api.md
@@ -565,8 +565,8 @@ Creates a locally scoped set of keyframes.
 import { keyframes, style } from '@vanilla-extract/css';
 
 const rotate = keyframes({
-  '0%': { rotate: '0deg' },
-  '100%': { rotate: '360deg' }
+  '0%': { transform: 'rotate(0deg)' },
+  '100%': { transform: 'rotate(360deg)' }
 });
 
 export const animated = style({
@@ -587,8 +587,8 @@ import {
 } from '@vanilla-extract/css';
 
 globalKeyframes('rotate', {
-  '0%': { rotate: '0deg' },
-  '100%': { rotate: '360deg' }
+  '0%': { transform: 'rotate(0deg)' },
+  '100%': { transform: 'rotate(360deg)' }
 });
 
 export const animated = style({


### PR DESCRIPTION
at the moment the "rotate" css properties have little browser support.
https://caniuse.com/?search=rotate