### PR TITLE
Fix recipe and sprinkles peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/preset-react": "^7.13.13",
     "@babel/preset-typescript": "^7.13.0",
     "@changesets/changelog-github": "^0.4.0",
-    "@changesets/cli": "^2.16.0",
+    "@changesets/cli": "^2.17.0",
     "@manypkg/cli": "^0.17.0",
     "@playwright/test": "^1.14.1",
     "@preconstruct/cli": "^2.0.1",

--- a/packages/recipes/package.json
+++ b/packages/recipes/package.json
@@ -23,9 +23,9 @@
   "author": "SEEK",
   "license": "MIT",
   "peerDependencies": {
-    "@vanilla-extract/css": "*"
+    "@vanilla-extract/css": "^1.0.0"
   },
   "devDependencies": {
-    "@vanilla-extract/css": "*"
+    "@vanilla-extract/css": "^1.0.0"
   }
 }

--- a/packages/sprinkles/package.json
+++ b/packages/sprinkles/package.json
@@ -25,9 +25,9 @@
   "author": "SEEK",
   "license": "MIT",
   "peerDependencies": {
-    "@vanilla-extract/css": "*"
+    "@vanilla-extract/css": "^1.0.0"
   },
   "devDependencies": {
-    "@vanilla-extract/css": "*"
+    "@vanilla-extract/css": "^1.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1983,15 +1983,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/apply-release-plan@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@changesets/apply-release-plan@npm:5.0.0"
+"@changesets/apply-release-plan@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "@changesets/apply-release-plan@npm:5.0.1"
   dependencies:
     "@babel/runtime": ^7.10.4
-    "@changesets/config": ^1.6.0
+    "@changesets/config": ^1.6.1
     "@changesets/get-version-range-type": ^0.3.2
-    "@changesets/git": ^1.1.1
-    "@changesets/types": ^4.0.0
+    "@changesets/git": ^1.1.2
+    "@changesets/types": ^4.0.1
     "@manypkg/get-packages": ^1.0.1
     detect-indent: ^6.0.0
     fs-extra: ^7.0.1
@@ -2000,21 +2000,21 @@ __metadata:
     prettier: ^1.19.1
     resolve-from: ^5.0.0
     semver: ^5.4.1
-  checksum: d43561e83192d183084d3837dd63fe618a173c056895784674ff14e4ebe4061bf2e3362642e65b4b23f129ecdac9e276222b5dfbbe0b0965a62a7878154a5cce
+  checksum: acd8239bd6fe0909d04c7d0a90b0186d148702d6886654dc3cf1ea905f0dd66521efd6054e7eb798a904bce6dd055bb320a043db5f37556dc8970c7199d4b073
   languageName: node
   linkType: hard
 
-"@changesets/assemble-release-plan@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@changesets/assemble-release-plan@npm:5.0.0"
+"@changesets/assemble-release-plan@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "@changesets/assemble-release-plan@npm:5.0.1"
   dependencies:
     "@babel/runtime": ^7.10.4
     "@changesets/errors": ^0.1.4
-    "@changesets/get-dependents-graph": ^1.2.1
-    "@changesets/types": ^4.0.0
+    "@changesets/get-dependents-graph": ^1.2.2
+    "@changesets/types": ^4.0.1
     "@manypkg/get-packages": ^1.0.1
     semver: ^5.4.1
-  checksum: 44878d43bbeaf08a8bd633190831be3c8e6293af7174b27233982be7291a642b2bf97579f59fd0994743f62533c5a99c4d0ced661c8b8b6b9e1ba487e2fdf513
+  checksum: bd76c3cc41aa175a09aca4165aa195ab4c15410d7740227d96793058df7c87639d4f1e164378fb32a989352c26ac8d062bbbc9cd2a93625107a164ec69e3fdd7
   languageName: node
   linkType: hard
 
@@ -2029,23 +2029,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/cli@npm:^2.16.0":
-  version: 2.16.0
-  resolution: "@changesets/cli@npm:2.16.0"
+"@changesets/cli@npm:^2.17.0":
+  version: 2.17.0
+  resolution: "@changesets/cli@npm:2.17.0"
   dependencies:
     "@babel/runtime": ^7.10.4
-    "@changesets/apply-release-plan": ^5.0.0
-    "@changesets/assemble-release-plan": ^5.0.0
-    "@changesets/config": ^1.6.0
+    "@changesets/apply-release-plan": ^5.0.1
+    "@changesets/assemble-release-plan": ^5.0.1
+    "@changesets/config": ^1.6.1
     "@changesets/errors": ^0.1.4
-    "@changesets/get-dependents-graph": ^1.2.1
-    "@changesets/get-release-plan": ^3.0.0
-    "@changesets/git": ^1.1.1
+    "@changesets/get-dependents-graph": ^1.2.2
+    "@changesets/get-release-plan": ^3.0.1
+    "@changesets/git": ^1.1.2
     "@changesets/logger": ^0.0.5
-    "@changesets/pre": ^1.0.6
-    "@changesets/read": ^0.4.7
-    "@changesets/types": ^4.0.0
-    "@changesets/write": ^0.1.4
+    "@changesets/pre": ^1.0.7
+    "@changesets/read": ^0.5.0
+    "@changesets/types": ^4.0.1
+    "@changesets/write": ^0.1.5
     "@manypkg/get-packages": ^1.0.1
     "@types/semver": ^6.0.0
     boxen: ^1.3.0
@@ -2065,22 +2065,22 @@ __metadata:
     tty-table: ^2.8.10
   bin:
     changeset: bin.js
-  checksum: aea003304788a211b709d7c0de418e0056df3e923b50d3beb93ff20d911bf6082a2f70c7d4484e3c18b21e7a63f677005ae67b7798706cfebdcaecafe25d8edb
+  checksum: 5f4c10ac237fd8049c49b78f1f24194d3894e1c3ecf8e3ff170d290bcc0cabf0546db0f494fbb549da0d5af36ae644eb20a8a7b54a1f5b69326053c42661df6a
   languageName: node
   linkType: hard
 
-"@changesets/config@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "@changesets/config@npm:1.6.0"
+"@changesets/config@npm:^1.6.1":
+  version: 1.6.1
+  resolution: "@changesets/config@npm:1.6.1"
   dependencies:
     "@changesets/errors": ^0.1.4
-    "@changesets/get-dependents-graph": ^1.2.1
+    "@changesets/get-dependents-graph": ^1.2.2
     "@changesets/logger": ^0.0.5
-    "@changesets/types": ^4.0.0
+    "@changesets/types": ^4.0.1
     "@manypkg/get-packages": ^1.0.1
     fs-extra: ^7.0.1
     micromatch: ^4.0.2
-  checksum: 99a08add7e48294c5825021bada7dccbc2c0edc22c723bcc936854a666a83570a6e4e178631aaa7a512577eab1d527105020f5acd50b6b8fa526c0262bcd5cf5
+  checksum: 0301dc9cfb7df81fa8beae27a9177653472f5ab2295c2fe882ee333c8da048664148809c2cb4569ac78f5019cf40c9d3e0d5bf5776cb2ce2c3774cd3d2cdb36b
   languageName: node
   linkType: hard
 
@@ -2093,16 +2093,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/get-dependents-graph@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "@changesets/get-dependents-graph@npm:1.2.1"
+"@changesets/get-dependents-graph@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "@changesets/get-dependents-graph@npm:1.2.2"
   dependencies:
-    "@changesets/types": ^4.0.0
+    "@changesets/types": ^4.0.1
     "@manypkg/get-packages": ^1.0.1
     chalk: ^2.1.0
     fs-extra: ^7.0.1
     semver: ^5.4.1
-  checksum: 13aef0b05d6d49cf777eed53e24d856890d6e209932466ddf6e4717af6b9286de717f2798d6821339404dc962b0d712fe68c484f3a3a324e1c183da1dce23e0f
+  checksum: ab299bf91b9812bfb1a6c2753c40c837c88722840977bf9be90a70749b4bf1a52dd6d34e4b272ba1fbc9fb968a558282823960829fc2800c74487d158523734b
   languageName: node
   linkType: hard
 
@@ -2116,18 +2116,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/get-release-plan@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@changesets/get-release-plan@npm:3.0.0"
+"@changesets/get-release-plan@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@changesets/get-release-plan@npm:3.0.1"
   dependencies:
     "@babel/runtime": ^7.10.4
-    "@changesets/assemble-release-plan": ^5.0.0
-    "@changesets/config": ^1.6.0
-    "@changesets/pre": ^1.0.6
-    "@changesets/read": ^0.4.7
-    "@changesets/types": ^4.0.0
+    "@changesets/assemble-release-plan": ^5.0.1
+    "@changesets/config": ^1.6.1
+    "@changesets/pre": ^1.0.7
+    "@changesets/read": ^0.5.0
+    "@changesets/types": ^4.0.1
     "@manypkg/get-packages": ^1.0.1
-  checksum: eac0c98fc8ab72d7a048788da0f0f946c11a0e22cff674544b517094cfff00664d456d9d78a0bdc708f6d5e9c118cc1bce7c18e13af7927a808111294b4c6ed2
+  checksum: f4100cdd6f902d52f83fbd6eb7075d0e44478a4f09e67ac4600d966449f16445edf4fea616beb5bd7e8e416284915dbc5a48255608995d6bb50c30d2a25da8f7
   languageName: node
   linkType: hard
 
@@ -2138,17 +2138,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/git@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@changesets/git@npm:1.1.1"
+"@changesets/git@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@changesets/git@npm:1.1.2"
   dependencies:
     "@babel/runtime": ^7.10.4
     "@changesets/errors": ^0.1.4
-    "@changesets/types": ^4.0.0
+    "@changesets/types": ^4.0.1
     "@manypkg/get-packages": ^1.0.1
     is-subdir: ^1.1.1
     spawndamnit: ^2.0.0
-  checksum: 6610b29401948cd6961e503743f8f25c90c0b55a4fc8a2c6773373ef2a153790c55d191db6a6507b36a88f5428617657a45297083ca4565444a32f09357bb928
+  checksum: 878a5b23be6985cd2b730e51c834409f22c5f9851dc15913e1543804d37fdf4dee6f556f6b22035b60a62a41cbc310f7df76a3bd1e18229c6658dbd1382d04ef
   languageName: node
   linkType: hard
 
@@ -2161,42 +2161,42 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/parse@npm:^0.3.8":
-  version: 0.3.8
-  resolution: "@changesets/parse@npm:0.3.8"
+"@changesets/parse@npm:^0.3.9":
+  version: 0.3.9
+  resolution: "@changesets/parse@npm:0.3.9"
   dependencies:
-    "@changesets/types": ^4.0.0
+    "@changesets/types": ^4.0.1
     js-yaml: ^3.13.1
-  checksum: bb01209d96fa6657df8c601f037436de0c502b012a0e0a71c7152fd1f4f4a05ce694765fac1411b7293a4a30b99ef418c8afd3018528c26be118b3b3f580ffec
+  checksum: 765ad29f8f9715732c6fd57e8566365423937cf44752f130d34a3cb6084e580331547ee67329ce183f10fa4a7a4cc6d27e04835e743024abb6415476bb6a305c
   languageName: node
   linkType: hard
 
-"@changesets/pre@npm:^1.0.6":
-  version: 1.0.6
-  resolution: "@changesets/pre@npm:1.0.6"
+"@changesets/pre@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "@changesets/pre@npm:1.0.7"
   dependencies:
     "@babel/runtime": ^7.10.4
     "@changesets/errors": ^0.1.4
-    "@changesets/types": ^4.0.0
+    "@changesets/types": ^4.0.1
     "@manypkg/get-packages": ^1.0.1
     fs-extra: ^7.0.1
-  checksum: 175f163a5bfc9cd803aa7dcc646af75fdc85fda988bc8470bb96744a12833b818b355d5a2788a3d6e2f0e300d3c3778962a8ffafa8b6ad2e8f3ba5da5d99f861
+  checksum: b4223485ef1a8d05c605a94dfdfa4729a8ceb57adf27520a3f83ce4cf0843775d6b459a6ba50f109ec1790fa23cf176bf203624aa0139675fcfa876e076c03f8
   languageName: node
   linkType: hard
 
-"@changesets/read@npm:^0.4.7":
-  version: 0.4.7
-  resolution: "@changesets/read@npm:0.4.7"
+"@changesets/read@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@changesets/read@npm:0.5.0"
   dependencies:
     "@babel/runtime": ^7.10.4
-    "@changesets/git": ^1.1.1
+    "@changesets/git": ^1.1.2
     "@changesets/logger": ^0.0.5
-    "@changesets/parse": ^0.3.8
-    "@changesets/types": ^4.0.0
+    "@changesets/parse": ^0.3.9
+    "@changesets/types": ^4.0.1
     chalk: ^2.1.0
     fs-extra: ^7.0.1
     p-filter: ^2.1.0
-  checksum: d5417e606b86ca64458af864bbb225997ce232376ee4496a61099e989a7dcc40176e8372676134d22457881922dfa314324da45b84aeb3564c3f181bb639a9cd
+  checksum: 2a45709a9149ca959d8dba17266bfcb97f5f00bf375c6b2646bb8cbf03ea57420e588cb7198224127465018f977bcadc50232f86064e1a4f322dea3bab7a8c59
   languageName: node
   linkType: hard
 
@@ -2214,16 +2214,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/write@npm:^0.1.4":
-  version: 0.1.4
-  resolution: "@changesets/write@npm:0.1.4"
+"@changesets/types@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@changesets/types@npm:4.0.1"
+  checksum: ec959d0a9c2e96e3d0785f6ea51c1d8c0851b7c36a15c6d8f3aaa412bb3bdc3a3cf7270c95dc686daf199ad959010cd14459e0a309bf546c8b76a6dadc81038b
+  languageName: node
+  linkType: hard
+
+"@changesets/write@npm:^0.1.5":
+  version: 0.1.5
+  resolution: "@changesets/write@npm:0.1.5"
   dependencies:
     "@babel/runtime": ^7.10.4
-    "@changesets/types": ^4.0.0
+    "@changesets/types": ^4.0.1
     fs-extra: ^7.0.1
     human-id: ^1.0.2
     prettier: ^1.19.1
-  checksum: 3d5432599b30baa94f02c30b273ffa06217fffc1eac0382ee01fe9a30203a774d1b3111fc8b5fe0e1d723daa062fb48e5b85a37e9d29265c4dfb9cc868622310
+  checksum: dcb9111980a045927760ab969ad30fda4affa7a47429efdd0232dfa5f90ba966e013488a38d63d21d1abf612824297c547492d20c0cdfb13dc3df6a42533d71a
   languageName: node
   linkType: hard
 
@@ -17334,7 +17341,7 @@ typescript@^4.1.3:
     "@babel/preset-react": ^7.13.13
     "@babel/preset-typescript": ^7.13.0
     "@changesets/changelog-github": ^0.4.0
-    "@changesets/cli": ^2.16.0
+    "@changesets/cli": ^2.17.0
     "@manypkg/cli": ^0.17.0
     "@playwright/test": ^1.14.1
     "@preconstruct/cli": ^2.0.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -3828,7 +3828,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@vanilla-extract/css@*, @vanilla-extract/css@1.5.0, @vanilla-extract/css@^1.5.0, @vanilla-extract/css@workspace:packages/css":
+"@vanilla-extract/css@*, @vanilla-extract/css@1.5.0, @vanilla-extract/css@^1.0.0, @vanilla-extract/css@^1.5.0, @vanilla-extract/css@workspace:packages/css":
   version: 0.0.0-use.local
   resolution: "@vanilla-extract/css@workspace:packages/css"
   dependencies:
@@ -3902,9 +3902,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@vanilla-extract/recipes@workspace:packages/recipes"
   dependencies:
-    "@vanilla-extract/css": "*"
+    "@vanilla-extract/css": ^1.0.0
   peerDependencies:
-    "@vanilla-extract/css": "*"
+    "@vanilla-extract/css": ^1.0.0
   languageName: unknown
   linkType: soft
 
@@ -3921,9 +3921,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@vanilla-extract/sprinkles@workspace:packages/sprinkles"
   dependencies:
-    "@vanilla-extract/css": "*"
+    "@vanilla-extract/css": ^1.0.0
   peerDependencies:
-    "@vanilla-extract/css": "*"
+    "@vanilla-extract/css": ^1.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
The `*` peer dep was causing changesets to always release. 