### PR TITLE
Add RecipeVariants type to get variants from recipes

### DIFF
--- a/.changeset/rare-lemons-study.md
+++ b/.changeset/rare-lemons-study.md
@@ -11,7 +11,7 @@ This type would help consumers easily get the variants type. Useful for typing t
 import { recipe } from '@vanilla-extract/recipes';
 import { reset } from './reset.css.ts';
 import { sprinkles } from './sprinkles.css.ts';
-// 
+
 export const button = recipe({
   variants: {
     color: {

--- a/.changeset/rare-lemons-study.md
+++ b/.changeset/rare-lemons-study.md
@@ -4,13 +4,11 @@
 
 Add `RecipeVariants` type to get variants from a recipe.
 
-This type would help consumers easily get the variants type. Useful for consuming variants from a Component, functions, or other parts of the code:
+This type allows you to extract the variants from the recipe function. Useful for consuming variants from a componen.
 
 ```ts
 // button.css.ts
 import { recipe } from '@vanilla-extract/recipes';
-import { reset } from './reset.css.ts';
-import { sprinkles } from './sprinkles.css.ts';
 
 export const button = recipe({
   variants: {

--- a/.changeset/rare-lemons-study.md
+++ b/.changeset/rare-lemons-study.md
@@ -11,31 +11,19 @@ This type would help consumers easily get the variants type. Useful for typing t
 import { recipe } from '@vanilla-extract/recipes';
 import { reset } from './reset.css.ts';
 import { sprinkles } from './sprinkles.css.ts';
-
+// 
 export const button = recipe({
   variants: {
     color: {
-      neutral: {
-        background: 'neutral'
-      },
-      brand: {
-        background: 'brand'
-      },
-      accend: {
-        background: 'accent'
-      }
+      neutral: { background: 'whitesmoke' },
+      brand: { background: 'blueviolet' },
+      accent: { background: 'slateblue' }
     },
     size: {
-      small: {
-        padding: 'small'
-      },
-      medium: {
-        padding: 'medium'
-      },
-      large: {
-        padding: 'large'
-      }
-    }
+      small: { padding: 12 },
+      medium: { padding: 16 },
+      large: { padding: 24 }
+    },
   }
 });
 
@@ -44,7 +32,7 @@ export type ButtonVariants = RecipeVariants<typeof button>;
 
 // the above will result in a type equivalent to:
 export type ButtonVariants = {
-  color?: 'neutral' | 'brand' | 'size';
+  color?: 'neutral' | 'brand' | 'accent';
   size?: 'small' | 'medium' | 'large';
 };
 ```

--- a/.changeset/rare-lemons-study.md
+++ b/.changeset/rare-lemons-study.md
@@ -2,13 +2,16 @@
 '@vanilla-extract/recipes': minor
 ---
 
-Add `RecipeVariants` type to get variants from a recipe.
+Add `RecipeVariants` type
 
-This type allows you to extract the variants from the recipe function. Useful for consuming variants from a component.
+A utility to make use of the recipe’s type interface. This can be useful when typing functions or component props that need to accept recipe values as part of their interface.
 
 ```ts
 // button.css.ts
-import { recipe, RecipeVariants } from '@vanilla-extract/recipes';
+import {
+  recipe,
+  RecipeVariants
+} from '@vanilla-extract/recipes';
 
 export const button = recipe({
   variants: {
@@ -21,11 +24,11 @@ export const button = recipe({
       small: { padding: 12 },
       medium: { padding: 16 },
       large: { padding: 24 }
-    },
+    }
   }
 });
 
-// Get the type 
+// Get the type
 export type ButtonVariants = RecipeVariants<typeof button>;
 
 // the above will result in a type equivalent to:

--- a/.changeset/rare-lemons-study.md
+++ b/.changeset/rare-lemons-study.md
@@ -8,7 +8,7 @@ This type allows you to extract the variants from the recipe function. Useful fo
 
 ```ts
 // button.css.ts
-import { recipe } from '@vanilla-extract/recipes';
+import { recipe, RecipeVariants } from '@vanilla-extract/recipes';
 
 export const button = recipe({
   variants: {

--- a/.changeset/rare-lemons-study.md
+++ b/.changeset/rare-lemons-study.md
@@ -4,7 +4,7 @@
 
 Add `RecipeVariants` type to get variants from a recipe.
 
-This type allows you to extract the variants from the recipe function. Useful for consuming variants from a componen.
+This type allows you to extract the variants from the recipe function. Useful for consuming variants from a component.
 
 ```ts
 // button.css.ts

--- a/.changeset/rare-lemons-study.md
+++ b/.changeset/rare-lemons-study.md
@@ -1,0 +1,31 @@
+---
+'@vanilla-extract/recipes': patch
+---
+
+Add `RecipeVariants` type to get variants from a recipe.
+
+This type would help consumers easily get the variants type. Useful for typing their components:
+
+```tsx
+const textRecipes = recipe({
+  variants: {
+    size: {
+      small: { fontSize: '12px' },
+      medium: { fontSize: '16px' },
+      large: { fontSize: '24px' },
+    },
+  },
+});
+
+type TextVariants = RecipeVariants<typeof textRecipes>;
+
+type Props = {
+  // ... other props
+} & TextVariants;
+
+function Text({ size, ...props }: Props) {
+  return <div {...props} className={textRecipes({ size })} />;
+}
+
+<Text size="small">Awesome text</Text>;
+```

--- a/.changeset/rare-lemons-study.md
+++ b/.changeset/rare-lemons-study.md
@@ -6,26 +6,45 @@ Add `RecipeVariants` type to get variants from a recipe.
 
 This type would help consumers easily get the variants type. Useful for typing their components:
 
-```tsx
-const textRecipes = recipe({
+```ts
+// button.css.ts
+import { recipe } from '@vanilla-extract/recipes';
+import { reset } from './reset.css.ts';
+import { sprinkles } from './sprinkles.css.ts';
+
+export const button = recipe({
   variants: {
-    size: {
-      small: { fontSize: '12px' },
-      medium: { fontSize: '16px' },
-      large: { fontSize: '24px' },
+    color: {
+      neutral: {
+        background: 'neutral'
+      },
+      brand: {
+        background: 'brand'
+      },
+      accend: {
+        background: 'accent'
+      }
     },
-  },
+    size: {
+      small: {
+        padding: 'small'
+      },
+      medium: {
+        padding: 'medium'
+      },
+      large: {
+        padding: 'large'
+      }
+    }
+  }
 });
 
-type TextVariants = RecipeVariants<typeof textRecipes>;
+// Get the type 
+export type ButtonVariants = RecipeVariants<typeof button>;
 
-type Props = {
-  // ... other props
-} & TextVariants;
-
-function Text({ size, ...props }: Props) {
-  return <div {...props} className={textRecipes({ size })} />;
-}
-
-<Text size="small">Awesome text</Text>;
+// the above will result in a type equivalent to:
+export type ButtonVariants = {
+  color?: 'neutral' | 'brand' | 'size';
+  size?: 'small' | 'medium' | 'large';
+};
 ```

--- a/.changeset/rare-lemons-study.md
+++ b/.changeset/rare-lemons-study.md
@@ -4,7 +4,7 @@
 
 Add `RecipeVariants` type to get variants from a recipe.
 
-This type would help consumers easily get the variants type. Useful for typing their components:
+This type would help consumers easily get the variants type. Useful for consuming variants from a Component, functions, or other parts of the code:
 
 ```ts
 // button.css.ts

--- a/.changeset/rare-lemons-study.md
+++ b/.changeset/rare-lemons-study.md
@@ -1,5 +1,5 @@
 ---
-'@vanilla-extract/recipes': patch
+'@vanilla-extract/recipes': minor
 ---
 
 Add `RecipeVariants` type to get variants from a recipe.

--- a/packages/recipes/src/index.ts
+++ b/packages/recipes/src/index.ts
@@ -10,6 +10,8 @@ import type {
   VariantSelection,
 } from './types';
 
+export type { RecipeVariants } from './types';
+
 function mapValues<Input extends Record<string, any>, OutputValue>(
   input: Input,
   fn: (value: Input[keyof Input]) => OutputValue,

--- a/packages/recipes/src/types.ts
+++ b/packages/recipes/src/types.ts
@@ -35,3 +35,6 @@ export type PatternOptions<Variants extends VariantGroups> = {
 export type RuntimeFn<Variants extends VariantGroups> = (
   options?: VariantSelection<Variants>,
 ) => string;
+
+export type RecipeVariants<RecipeFn extends RuntimeFn<VariantGroups>> =
+  Parameters<RecipeFn>[0];

--- a/site/docs/recipes-api.md
+++ b/site/docs/recipes-api.md
@@ -113,13 +113,16 @@ export const button = recipe({
 });
 ```
 
-## TypeScript
+## RecipeVariants
 
-If you want to use the type of your variants in a component API, you can use the `RecipeVariants` type.
+A utility to make use of the recipe’s type interface. This can be useful when typing functions or component props that need to accept recipe values as part of their interface.
 
 ```ts
 // button.css.ts
-import { recipe, RecipeVariants } from '@vanilla-extract/recipes';
+import {
+  recipe,
+  RecipeVariants
+} from '@vanilla-extract/recipes';
 
 export const button = recipe({
   variants: {
@@ -132,11 +135,11 @@ export const button = recipe({
       small: { padding: 12 },
       medium: { padding: 16 },
       large: { padding: 24 }
-    },
+    }
   }
 });
 
-// Get the type 
+// Get the type
 export type ButtonVariants = RecipeVariants<typeof button>;
 
 // the above will result in a type equivalent to:

--- a/site/docs/recipes-api.md
+++ b/site/docs/recipes-api.md
@@ -112,3 +112,40 @@ export const button = recipe({
   }
 });
 ```
+
+## TypeScript
+
+Our API's are completely typed, meaning `recipe` return value will autocomplete as expected.
+
+If you want to use the type of your variants from a Component or other parts of your code, you can get that type using `RecipeVariants`:
+
+```ts
+// button.css.ts
+import { recipe } from '@vanilla-extract/recipes';
+import { reset } from './reset.css.ts';
+import { sprinkles } from './sprinkles.css.ts';
+
+export const button = recipe({
+  variants: {
+    color: {
+      neutral: sprinkles({ background: 'neutral' }),
+      brand: sprinkles({ background: 'brand' }),
+      accent: sprinkles({ background: 'accent' })
+    },
+    size: {
+      small: sprinkles({ padding: 'small' }),
+      medium: sprinkles({ padding: 'medium' }),
+      large: sprinkles({ padding: 'large' })
+    }
+  }
+});
+
+// Get the type 
+type ButtonVariants = RecipeVariants<typeof button>;
+
+// the above will result in a similar type to:
+type ButtonVariants = {
+  color: 'neutral' | 'brand' | 'size';
+  size: 'small' | 'medium' | 'large';
+};
+```

--- a/site/docs/recipes-api.md
+++ b/site/docs/recipes-api.md
@@ -115,7 +115,7 @@ export const button = recipe({
 
 ## TypeScript
 
-Our API's are completely typed, meaning `recipe` return value will autocomplete as expected.
+Our API's are completely typed, meaning the function returned by `recipe` will autocomplete as expected.
 
 If you want to use the type of your variants from a Component or other parts of your code, you can get that type using `RecipeVariants`:
 
@@ -128,27 +128,15 @@ import { sprinkles } from './sprinkles.css.ts';
 export const button = recipe({
   variants: {
     color: {
-      neutral: {
-        background: 'neutral'
-      },
-      brand: {
-        background: 'brand'
-      },
-      accend: {
-        background: 'accent'
-      }
+      neutral: { background: 'whitesmoke' },
+      brand: { background: 'blueviolet' },
+      accent: { background: 'slateblue' }
     },
     size: {
-      small: {
-        padding: 'small'
-      },
-      medium: {
-        padding: 'medium'
-      },
-      large: {
-        padding: 'large'
-      }
-    }
+      small: { padding: 12 },
+      medium: { padding: 16 },
+      large: { padding: 24 }
+    },
   }
 });
 
@@ -157,7 +145,7 @@ export type ButtonVariants = RecipeVariants<typeof button>;
 
 // the above will result in a type equivalent to:
 export type ButtonVariants = {
-  color?: 'neutral' | 'brand' | 'size';
+  color?: 'neutral' | 'brand' | 'accent';
   size?: 'small' | 'medium' | 'large';
 };
 ```

--- a/site/docs/recipes-api.md
+++ b/site/docs/recipes-api.md
@@ -128,24 +128,36 @@ import { sprinkles } from './sprinkles.css.ts';
 export const button = recipe({
   variants: {
     color: {
-      neutral: sprinkles({ background: 'neutral' }),
-      brand: sprinkles({ background: 'brand' }),
-      accent: sprinkles({ background: 'accent' })
+      neutral: {
+        background: 'neutral'
+      },
+      brand: {
+        background: 'brand'
+      },
+      accend: {
+        background: 'accent'
+      }
     },
     size: {
-      small: sprinkles({ padding: 'small' }),
-      medium: sprinkles({ padding: 'medium' }),
-      large: sprinkles({ padding: 'large' })
+      small: {
+        padding: 'small'
+      },
+      medium: {
+        padding: 'medium'
+      },
+      large: {
+        padding: 'large'
+      }
     }
   }
 });
 
 // Get the type 
-type ButtonVariants = RecipeVariants<typeof button>;
+export type ButtonVariants = RecipeVariants<typeof button>;
 
 // the above will result in a type equivalent to:
-type ButtonVariants = {
-  color: 'neutral' | 'brand' | 'size';
-  size: 'small' | 'medium' | 'large';
+export type ButtonVariants = {
+  color?: 'neutral' | 'brand' | 'size';
+  size?: 'small' | 'medium' | 'large';
 };
 ```

--- a/site/docs/recipes-api.md
+++ b/site/docs/recipes-api.md
@@ -115,15 +115,11 @@ export const button = recipe({
 
 ## TypeScript
 
-Our API's are completely typed, meaning the function returned by `recipe` will autocomplete as expected.
-
-If you want to use the type of your variants from a Component or other parts of your code, you can get that type using `RecipeVariants`:
+If you want to use the type of your variants in a component API, you can use the `RecipeVariants` type.
 
 ```ts
 // button.css.ts
-import { recipe } from '@vanilla-extract/recipes';
-import { reset } from './reset.css.ts';
-import { sprinkles } from './sprinkles.css.ts';
+import { recipe, RecipeVariants } from '@vanilla-extract/recipes';
 
 export const button = recipe({
   variants: {

--- a/site/docs/recipes-api.md
+++ b/site/docs/recipes-api.md
@@ -143,7 +143,7 @@ export const button = recipe({
 // Get the type 
 type ButtonVariants = RecipeVariants<typeof button>;
 
-// the above will result in a similar type to:
+// the above will result in a type equivalent to:
 type ButtonVariants = {
   color: 'neutral' | 'brand' | 'size';
   size: 'small' | 'medium' | 'large';

--- a/tests/recipes/recipes-type-tests.ts
+++ b/tests/recipes/recipes-type-tests.ts
@@ -6,6 +6,8 @@ import { recipe, RecipeVariants } from '@vanilla-extract/recipes';
 // @ts-expect-error Unused args
 const noop = (...args: Array<any>) => {};
 
+type AssertIsString<S> = S extends string ? true : never;
+
 () => {
   const textRecipes = recipe({
     variants: {
@@ -29,6 +31,15 @@ const noop = (...args: Array<any>) => {};
     color: 'brand',
   };
 
+  const validTextVariant: TextVariants = {
+    size: 'large',
+  };
+
+  const recipeStyles = textRecipes({ size: 'small' });
+  const recipeShouldReturnString: AssertIsString<typeof recipeStyles> = true;
+
   noop(invalidVariantValue);
   noop(invalidVariantName);
+  noop(validTextVariant);
+  noop(recipeShouldReturnString);
 };

--- a/tests/recipes/recipes-type-tests.ts
+++ b/tests/recipes/recipes-type-tests.ts
@@ -1,0 +1,34 @@
+/*
+    This file is for validating types, it is not designed to be executed
+*/
+import { recipe, RecipeVariants } from '@vanilla-extract/recipes';
+
+// @ts-expect-error Unused args
+const noop = (...args: Array<any>) => {};
+
+() => {
+  const textRecipes = recipe({
+    variants: {
+      size: {
+        small: { fontSize: '12px' },
+        medium: { fontSize: '16px' },
+        large: { fontSize: '24px' },
+      },
+    },
+  });
+
+  type TextVariants = RecipeVariants<typeof textRecipes>;
+
+  const invalidVariantValue: TextVariants = {
+    // @ts-expect-error Type '"extraLarge"' is not assignable to type '"small" | "large" | "medium" | undefined'.
+    size: 'extraLarge',
+  };
+
+  const invalidVariantName: TextVariants = {
+    // @ts-expect-error Property 'color' does not exist in type
+    color: 'brand',
+  };
+
+  noop(invalidVariantValue);
+  noop(invalidVariantName);
+};


### PR DESCRIPTION
# Description
Add `RecipeVariants` type to get variants from a recipe.

This type would help consumers easily get the variants type. Useful for typing their components:

```tsx
const textRecipes = recipe({
  variants: {
    size: {
      small: { fontSize: '12px' },
      medium: { fontSize: '16px' },
      large: { fontSize: '24px' },
    },
  },
});

type TextVariants = RecipeVariants<typeof textRecipes>;

type Props = {
  // ... other props
} & TextVariants;

function Text({ size, ...props }: Props) {
  return <div {...props} className={textRecipes({ size })} />;
}

<Text size="small">Awesome text</Text>;
```

For more context, these types are easy to get from outside the lib using `Parameters`, but having these utilities would make it easy and provide an official way to get these, plus if the way to get the type changes, consumers won't have to worry about it as the type abstracts this.

## Other Options

* Maybe exposing `recipe.variants` (similar to the `properties` property on the sprinkles returned function), then doing:
```ts
type Variants = typeof recipe.variants;
```

* Even if the type is something that ends up not being added, I think at least having some documentation into how to get these types is useful for library consumers.

If this ends up being useful, I can also add a similar type for sprinkles.