### PR TITLE
Handle pre-compiled `createTheme` destructuring in Babel plugin

### DIFF
--- a/.changeset/flat-colts-cheer.md
+++ b/.changeset/flat-colts-cheer.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/babel-plugin': patch
+---
+
+Handle array destructuring from `createTheme` when it's already been compiled

--- a/packages/babel-plugin/src/index.test.ts
+++ b/packages/babel-plugin/src/index.test.ts
@@ -411,6 +411,32 @@ describe('babel plugin', () => {
     `);
   });
 
+  it('should handle createTheme using destructuring when already compiled', () => {
+    const source = `
+      import { createTheme } from '@vanilla-extract/css';
+
+      var _createTheme = createTheme({}),
+        _createTheme2 = _slicedToArray(_createTheme, 2),
+        myThemeClass = _createTheme2[0],
+        vars = _createTheme2[1];
+    `;
+
+    expect(transform(source)).toMatchInlineSnapshot(`
+      "import * as __vanilla_filescope__ from '@vanilla-extract/css/fileScope';
+
+      __vanilla_filescope__.setFileScope(\\"src/dir/mockFilename.css.ts\\", \\"@vanilla-extract/babel-plugin\\");
+
+      import { createTheme } from '@vanilla-extract/css';
+
+      var _createTheme = createTheme({}, \\"myThemeClass\\"),
+          _createTheme2 = _slicedToArray(_createTheme, 2),
+          myThemeClass = _createTheme2[0],
+          vars = _createTheme2[1];
+
+      __vanilla_filescope__.endFileScope();"
+    `);
+  });
+
   it('should handle createGlobalTheme', () => {
     const source = `
       import { createGlobalTheme } from '@vanilla-extract/css';

--- a/packages/babel-plugin/src/index.ts
+++ b/packages/babel-plugin/src/index.ts
@@ -103,8 +103,7 @@ const getDebugId = (path: NodePath<t.CallExpression>) => {
 
     if (
       t.isCallExpression(themeDeclarator.init) &&
-      t.isIdentifier(themeDeclarator.init.callee) &&
-      themeDeclarator.init.callee.name === 'createTheme' &&
+      t.isIdentifier(themeDeclarator.init.callee, { name: 'createTheme' }) &&
       t.isVariableDeclarator(classNameDeclarator) &&
       t.isIdentifier(classNameDeclarator.id)
     ) {


### PR DESCRIPTION
Fixes #369