### PR TITLE
Use a virtual prefix for Vite plugin

### DIFF
--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -22,6 +22,9 @@ interface Options {
    */
   devStyleRuntime?: 'vite' | 'vanilla-extract';
 }
+
+const VIRTUAL_PREFIX = `/@vanilla-extract:`;
+
 export function vanillaExtractPlugin({
   identifiers,
   devStyleRuntime = 'vite',
@@ -52,14 +55,19 @@ export function vanillaExtractPlugin({
         );
         cssMap.set(shortHashFileName, source);
 
-        return shortHashFileName;
+        return VIRTUAL_PREFIX + shortHashFileName;
       }
     },
     load(id) {
-      if (cssMap.has(id)) {
-        const css = cssMap.get(id);
+      if (!id.startsWith(VIRTUAL_PREFIX)) {
+        return null;
+      }
 
-        cssMap.delete(id);
+      const shortHashFileName = id.substr(VIRTUAL_PREFIX.length);
+      if (cssMap.has(shortHashFileName)) {
+        const css = cssMap.get(shortHashFileName);
+
+        cssMap.delete(shortHashFileName);
 
         return css;
       }

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -75,12 +75,16 @@ export function vanillaExtractPlugin({
       return null;
     },
     async transform(code, id, ssr) {
-      if (!cssFileFilter.test(id)) {
+      if (!id.startsWith(VIRTUAL_PREFIX)) {
         return null;
       }
+      const shortHashFileName = id.substr(VIRTUAL_PREFIX.length);
 
-      const usedIndex = id.indexOf('?used');
-      const fixedId = usedIndex > 0 ? id.substring(0, usedIndex) : id;
+      const usedIndex = shortHashFileName.indexOf('?used');
+      const fixedId =
+        usedIndex > 0
+          ? shortHashFileName.substring(0, usedIndex)
+          : shortHashFileName;
 
       if (ssr || useRuntime) {
         return addFileScope({


### PR DESCRIPTION
This adds an explicit prefix to virtual modules generated by the Vite plugin.

It helps tell Vite that these files don't exist so it doesn't try to optimise them (it seems to fix #397) and fixes https://github.com/zenclabs/reactpreview/issues/52.

See https://vitejs.dev/guide/api-plugin.html#importing-a-virtual-file for more info. Note the `/` prefix is required or Vite automatically adds an additional `/@id/` to the module ID before `load()` gets invoked (I'm not sure why).

I've tested this change manually but I'm not 100% confident that I haven't broken anything. I was wondering if setting up some tests in the form of a simple app with associated Puppeteer tests would be beneficial too?