### PR TITLE
Add Discord link to site and issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ labels: ''
 assignees: ''
 ---
 
-<!-- NOTE: Issues should only be used for actual issues. Any feature requests or general feedback should be raised in [Github Discussions](https://github.com/seek-oss/vanilla-extract/discussions) or [Discord](https://discord.gg/6nCfPwwz6w) -->
+<!-- NOTE: Issues should only be used for actual issues. Any feature requests or general feedback should be raised in Github Discussions (https://github.com/seek-oss/vanilla-extract/discussions) or Discord (https://discord.gg/6nCfPwwz6w) -->
 
 ### Describe the bug
 <!-- A clear and concise description of what the bug is, including any error message that were displayed. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ labels: ''
 assignees: ''
 ---
 
-<!-- NOTE: Issues should only be used for actual issues. Any feature requests or general feedback should be raised in [Github Discussions](https://github.com/seek-oss/vanilla-extract/discussions) -->
+<!-- NOTE: Issues should only be used for actual issues. Any feature requests or general feedback should be raised in [Github Discussions](https://github.com/seek-oss/vanilla-extract/discussions) or [Discord](https://discord.gg/6nCfPwwz6w) -->
 
 ### Describe the bug
 <!-- A clear and concise description of what the bug is, including any error message that were displayed. -->

--- a/site/src/HomePage/HomePage.tsx
+++ b/site/src/HomePage/HomePage.tsx
@@ -624,6 +624,14 @@ export const HomePage = () => {
                   >
                     Discussions
                   </Link>
+                  <Link
+                    to="https://discord.gg/6nCfPwwz6w"
+                    size="small"
+                    color="secondary"
+                    baseline
+                  >
+                    Discord
+                  </Link>
                 </Stack>
 
                 <Stack space="xlarge" align="center">


### PR DESCRIPTION
Also removed redundant markdown formatting of links in the issue template's HTML comment since it's only ever displayed as plain text.