### PR TITLE
Update `BooleanMap` type

### DIFF
--- a/packages/recipes/src/types.ts
+++ b/packages/recipes/src/types.ts
@@ -4,7 +4,7 @@ type RecipeStyleRule = ComplexStyleRule | string;
 
 export type VariantDefinitions = Record<string, RecipeStyleRule>;
 
-type BooleanMap<T> = T extends 'true' ? true : T;
+type BooleanMap<T> = T extends 'true' | 'false' ? boolean : T;
 
 export type VariantGroups = Record<string, VariantDefinitions>;
 export type VariantSelection<Variants extends VariantGroups> = {


### PR DESCRIPTION
Updates the `BooleanMap` type to include both `true` and `false` cases and to map to `boolean` instead of `true`. Before this change a `Button` that had a `loading` variant (and therefore prop) would need to change write the following:

```
<Button loading={conditionalBooleanPropIsLoading as true | undefined}>
   etc
</Button>
```

With this change you will no longer need to do that and can more clearly write:

```
<Button loading={conditionalBooleanPropIsLoading}>
   etc
</Button>
```

This also aligns with stitches' behaviour.