### PR TITLE
Add missing @vanilla-extract/css peer dependency

### DIFF
--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -26,6 +26,7 @@
   "author": "SEEK",
   "license": "MIT",
   "peerDependencies": {
+    "@vanilla-extract/css": "*",
     "webpack": "^4.30.0 || ^5.20.2"
   },
   "dependencies": {


### PR DESCRIPTION
`@vanilla-extract/webpack-plugin` requires `@vanilla-extract/css` but it is not declared as a dependency. This leads to build errors when using strict node linkers like pnp or pnpm.