### PR TITLE
Vite plugin: Use normalized path as a key for storing processed vanilla css.

### DIFF
--- a/.changeset/giant-llamas-glow.md
+++ b/.changeset/giant-llamas-glow.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Use normalized path as a key for storing processed vanilla css.

--- a/.changeset/giant-llamas-glow.md
+++ b/.changeset/giant-llamas-glow.md
@@ -2,4 +2,4 @@
 '@vanilla-extract/vite-plugin': patch
 ---
 
-Use normalized path as a key for storing processed vanilla css.
+Prefix virtual files with `/@ve-css:` so that the paths do not get overridden.

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -65,12 +65,13 @@ export function vanillaExtractPlugin({ identifiers }: Options = {}): Plugin {
 
       if (extensionIndex > 0) {
         const fileScopeId = id.substring(0, extensionIndex);
+        const normalizedFileId = normalizePath(`/${fileScopeId}`);
 
-        if (!cssMap.has(fileScopeId)) {
-          throw new Error(`Unable to locate ${fileScopeId} in the CSS map.`);
+        if (!cssMap.has(normalizedFileId)) {
+          throw new Error(`Unable to locate ${normalizedFileId} in the CSS map.`);
         }
 
-        const css = cssMap.get(fileScopeId)!;
+        const css = cssMap.get(normalizedFileId)!;
 
         if (!server) {
           return css;
@@ -133,8 +134,9 @@ export function vanillaExtractPlugin({ identifiers }: Options = {}): Plugin {
         serializeVirtualCssPath: ({ fileScope, source }) => {
           const fileId = stringifyFileScope(fileScope);
           const id = `${fileId}${virtualExt}`;
+          const normalizedFileId = normalizePath(`/${fileId}`);
 
-          if (server && cssMap.has(fileId) && cssMap.get(fileId) !== source) {
+          if (server && cssMap.has(normalizedFileId) && cssMap.get(normalizedFileId) !== source) {
             const { moduleGraph } = server;
             const module = moduleGraph.getModuleById(id);
 
@@ -144,12 +146,12 @@ export function vanillaExtractPlugin({ identifiers }: Options = {}): Plugin {
 
             server.ws.send({
               type: 'custom',
-              event: styleUpdateEvent(fileId),
+              event: styleUpdateEvent(normalizedFileId),
               data: source,
             });
           }
 
-          cssMap.set(fileId, source);
+          cssMap.set(normalizedFileId, source);
 
           return `import "${id}";`;
         },

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -140,7 +140,7 @@ export function vanillaExtractPlugin({ identifiers }: Options = {}): Plugin {
           identifiers ?? (config.mode === 'production' ? 'short' : 'debug'),
         serializeVirtualCssPath: ({ fileScope, source }) => {
           const fileId = stringifyFileScope(fileScope);
-          const id = `${fileId}${virtualExt}`;
+          const id = `/@ve-css:${fileId}${virtualExt}`;
 
           if (server && cssMap.has(fileId) && cssMap.get(fileId) !== source) {
             const { moduleGraph } = server;
@@ -159,7 +159,7 @@ export function vanillaExtractPlugin({ identifiers }: Options = {}): Plugin {
 
           cssMap.set(fileId, source);
 
-          return `import "/@ve-css:${id}";`;
+          return `import "${id}";`;
         },
       });
     },


### PR DESCRIPTION
Fixes #427

When used with Vite, if `*.css.ts` module is imported from _outside_ of the root directory, the following error occurs:

```
Unable to locate /path-to.css.ts$$$@scope/package-name in the CSS map.
```

This happens, because the path `../path-to.css.ts` gets overridden to `/../path-to.css.ts` (by `vite:import-analysis`) and then consequently to `/path-to.css.ts` (by `vite.normalizePath`). As a result, `cssMap` stores the source under a different key as it is being retrieved.

This is where the source is stored under `../path-to.css.ts$$$@scope/package-name`:
https://github.com/seek-oss/vanilla-extract/blob/076b02d91f22d0b61df2dd9edd875f86ac4a55ea/packages/vite-plugin/src/index.ts#L152

This is where the we are trying to retrieve the source by wrong key (`/path-to.css.ts$$$@scope/package-name`):
https://github.com/seek-oss/vanilla-extract/blob/076b02d91f22d0b61df2dd9edd875f86ac4a55ea/packages/vite-plugin/src/index.ts#L69

This PR should fix the problem, as it replaces the use of relative paths as keys with normalise paths.
