### PR TITLE
Recipes: Add `requiredVariants` option

### DIFF
--- a/.changeset/strong-poets-mate.md
+++ b/.changeset/strong-poets-mate.md
@@ -1,0 +1,25 @@
+---
+'@vanilla-extract/recipes': minor
+---
+
+Add `requiredVariants` option
+
+You can now specify that certain variants are required via the `requiredVariants` option which accepts an array of variant names.
+
+**Example usage:**
+
+```ts
+import { recipe } from '@vanilla-extract/recipes';
+
+export const button = recipe({
+  variants: {
+    color: {
+      neutral: { background: 'whitesmoke' },
+      brand: { background: 'blueviolet' },
+      accent: { background: 'slateblue' }
+    },
+  },
+
+  requiredVariants: ['color'],
+});
+```

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "jest": "^26.6.3",
     "prettier": "^2.3.2",
     "ts-node": "^9.1.1",
-    "typescript": "^4.1.3"
+    "typescript": "^4.4.4"
   }
 }

--- a/packages/recipes/src/index.ts
+++ b/packages/recipes/src/index.ts
@@ -25,14 +25,18 @@ function mapValues<Input extends Record<string, any>, OutputValue>(
   return result;
 }
 
-export function recipe<Variants extends VariantGroups>(
-  options: PatternOptions<Variants>,
+export function recipe<
+  Variants extends VariantGroups,
+  RequiredVariants extends Array<keyof Variants> = [],
+>(
+  options: PatternOptions<Variants, RequiredVariants>,
   debugId?: string,
-): RuntimeFn<Variants> {
+): RuntimeFn<Variants, RequiredVariants> {
   const {
     variants = {},
     defaultVariants = {},
     compoundVariants = [],
+    requiredVariants,
     base = '',
   } = options;
 
@@ -61,11 +65,12 @@ export function recipe<Variants extends VariantGroups>(
     ]);
   }
 
-  const config: PatternResult<Variants> = {
+  const config: PatternResult<Variants, RequiredVariants> = {
     defaultClassName,
     variantClassNames,
     defaultVariants,
     compoundVariants: compounds,
+    requiredVariants,
   };
 
   return addRecipe(createRuntimeFn(config), {

--- a/packages/recipes/src/types.ts
+++ b/packages/recipes/src/types.ts
@@ -11,13 +11,17 @@ export type VariantSelection<Variants extends VariantGroups> = {
   [VariantGroup in keyof Variants]?: BooleanMap<keyof Variants[VariantGroup]>;
 };
 
-export type PatternResult<Variants extends VariantGroups> = {
+export type PatternResult<
+  Variants extends VariantGroups,
+  RequiredVariants extends Array<keyof Variants>,
+> = {
   defaultClassName: string;
   variantClassNames: {
     [P in keyof Variants]: { [P in keyof Variants[keyof Variants]]: string };
   };
   defaultVariants: VariantSelection<Variants>;
   compoundVariants: Array<[VariantSelection<Variants>, string]>;
+  requiredVariants?: RequiredVariants;
 };
 
 export interface CompoundVariant<Variants extends VariantGroups> {
@@ -25,16 +29,29 @@ export interface CompoundVariant<Variants extends VariantGroups> {
   style: RecipeStyleRule;
 }
 
-export type PatternOptions<Variants extends VariantGroups> = {
+export type PatternOptions<
+  Variants extends VariantGroups,
+  RequiredVariants extends Array<keyof Variants>,
+> = {
   base?: RecipeStyleRule;
   variants?: Variants;
   defaultVariants?: VariantSelection<Variants>;
   compoundVariants?: Array<CompoundVariant<Variants>>;
+  requiredVariants?: RequiredVariants;
 };
 
-export type RuntimeFn<Variants extends VariantGroups> = (
-  options?: VariantSelection<Variants>,
-) => string;
+export type RuntimeFn<
+  Variants extends VariantGroups,
+  RequiredVariants extends Array<keyof Variants>,
+> = (RequiredVariants extends { length: 0 }
+  ? (options?: VariantSelection<Variants>) => string
+  : (
+      options: Omit<VariantSelection<Variants>, RequiredVariants[number]> &
+        Required<Pick<VariantSelection<Variants>, RequiredVariants[number]>>,
+    ) => string) & {
+  __recipeFn: true;
+};
 
-export type RecipeVariants<RecipeFn extends RuntimeFn<VariantGroups>> =
-  Parameters<RecipeFn>[0];
+export type RecipeVariants<
+  RecipeFn extends ((...args: any) => any) & { __recipeFn: true },
+> = Parameters<RecipeFn>[0];

--- a/site/docs/recipes-api.md
+++ b/site/docs/recipes-api.md
@@ -43,6 +43,12 @@ export const button = recipe({
     }
   },
 
+  defaultVariants: {
+    size: 'medium'
+  },
+
+  requiredVariants: ['color'],
+
   // Applied when multiple variants are set at once
   compoundVariants: [
     {
@@ -54,12 +60,7 @@ export const button = recipe({
         background: 'ghostwhite'
       }
     }
-  ],
-
-  defaultVariants: {
-    color: 'accent',
-    size: 'medium'
-  }
+  ]
 });
 ```
 

--- a/tests/recipes/recipes-type-tests.ts
+++ b/tests/recipes/recipes-type-tests.ts
@@ -42,4 +42,49 @@ type AssertIsString<S> = S extends string ? true : never;
   noop(invalidVariantName);
   noop(validTextVariant);
   noop(recipeShouldReturnString);
+
+  const requiredRecipe = recipe({
+    variants: {
+      required: {
+        a: { fontSize: '12px' },
+        b: { fontSize: '16px' },
+        c: { fontSize: '24px' },
+      },
+      optional: {
+        a: { color: 'red' },
+        b: { color: 'green' },
+        c: { color: 'blue' },
+      },
+    },
+
+    requiredVariants: ['required'],
+  });
+
+  // @ts-expect-error An argument for 'options' was not provided.
+  requiredRecipe();
+
+  // @ts-expect-error Property 'required' is missing in type '{}'
+  requiredRecipe({});
+
+  // @ts-expect-error Property 'required' is missing in type '{ optional: "a"; }'
+  requiredRecipe({ optional: 'a' });
+
+  requiredRecipe({ required: 'a' });
+  requiredRecipe({ required: 'b', optional: 'c' });
+
+  type RequiredVariants = RecipeVariants<typeof requiredRecipe>;
+
+  const checkRequiredVariantsType = (variants: RequiredVariants) => variants;
+
+  // @ts-expect-error Type 'undefined' is not assignable to type ...
+  checkRequiredVariantsType(undefined);
+
+  // @ts-expect-error Property 'required' is missing in type '{}'
+  checkRequiredVariantsType({});
+
+  // @ts-expect-error Property 'required' is missing in type '{ optional: "a"; }'
+  checkRequiredVariantsType({ optional: 'a' });
+
+  checkRequiredVariantsType({ required: 'a' });
+  checkRequiredVariantsType({ required: 'b', optional: 'c' });
 };

--- a/tests/recipes/recipes.css.ts
+++ b/tests/recipes/recipes.css.ts
@@ -29,3 +29,29 @@ export const basic = recipe({
     },
   ],
 });
+
+export const requiredVariants = recipe({
+  base: {},
+
+  variants: {
+    required_1: {
+      a: {},
+      b: {},
+      c: {},
+    },
+
+    required_2: {
+      a: {},
+      b: {},
+      c: {},
+    },
+
+    optional: {
+      a: {},
+      b: {},
+      c: {},
+    },
+  },
+
+  requiredVariants: ['required_1', 'required_2'],
+});

--- a/tests/recipes/recipes.test.ts
+++ b/tests/recipes/recipes.test.ts
@@ -1,4 +1,4 @@
-import { basic } from './recipes.css';
+import { basic, requiredVariants } from './recipes.css';
 
 describe('recipes', () => {
   it('should return default variants for no options', () => {
@@ -43,5 +43,40 @@ describe('recipes', () => {
     expect(basic({ color: 'red' })).toMatchInlineSnapshot(
       `"recipes_basic__niwegb0 recipes_basic_spaceWithDefault_small__niwegb1 recipes_basic_color_red__niwegb5 recipes_basic_compound_0__niwegb7"`,
     );
+  });
+
+  describe('requiredVariants', () => {
+    it('should throw an error when no options provided', () => {
+      expect(() => {
+        // @ts-expect-error
+        requiredVariants();
+      }).toThrowErrorMatchingInlineSnapshot(
+        `"Required variants not provided: \\"required_1\\", \\"required_2\\""`,
+      );
+    });
+
+    it('should throw an error when options is empty', () => {
+      expect(() => {
+        // @ts-expect-error
+        requiredVariants({});
+      }).toThrowErrorMatchingInlineSnapshot(
+        `"Required variants not provided: \\"required_1\\", \\"required_2\\""`,
+      );
+    });
+
+    it('should throw an error when a single required variant is missing', () => {
+      expect(() => {
+        // @ts-expect-error
+        requiredVariants({ required_1: 'a' });
+      }).toThrowErrorMatchingInlineSnapshot(
+        `"Required variants not provided: \\"required_2\\""`,
+      );
+    });
+
+    it('should not throw an error when required variants are provided', () => {
+      expect(() => {
+        requiredVariants({ required_1: 'a', required_2: 'b' });
+      }).not.toThrow();
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -16863,23 +16863,23 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-typescript@^4.1.3:
-  version: 4.2.3
-  resolution: "typescript@npm:4.2.3"
+"typescript@npm:^4.4.4":
+  version: 4.4.4
+  resolution: "typescript@npm:4.4.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: b4a2020c021211184ac15caf59936b2089c13e79685f340a31aaa839c9de2f73b44a5e3757292de6cdad2ed967aef80d4592161b814cc29c0570f261850c4bca
+  checksum: 89ecb8436bb48ef5594d49289f5f89103071716b6e4844278f4fb3362856e31203e187a9c76d205c3f0b674d221a058fd28310dbcbcf5d95e9a57229bb5203f1
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.1.3#~builtin<compat/typescript>":
-  version: 4.2.3
-  resolution: "typescript@patch:typescript@npm%3A4.2.3#~builtin<compat/typescript>::version=4.2.3&hash=ddd1e8"
+"typescript@patch:typescript@^4.4.4#~builtin<compat/typescript>":
+  version: 4.4.4
+  resolution: "typescript@patch:typescript@npm%3A4.4.4#~builtin<compat/typescript>::version=4.4.4&hash=ddd1e8"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: f97b1f885444f13c340127a0918b17d0c4e5c248f99203a22712b3b43d7129c9c7b95437e4f1de99edf79d3046fa9e15356fb5d27d9d94e47a98158c8b18fda5
+  checksum: bd629ad0da4a15d79aaad56baf3ee7d96f6a181760d430ae77f8c5325df7bffd9edee57544a3970e3651e8b796fe03a5838a7eb39c6d46cc3866c0b23d36a0dd
   languageName: node
   linkType: hard
 
@@ -17498,7 +17498,7 @@ typescript@^4.1.3:
     jest: ^26.6.3
     prettier: ^2.3.2
     ts-node: ^9.1.1
-    typescript: ^4.1.3
+    typescript: ^4.4.4
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
See changeset for details.

I know this is something we talked about ages ago, but https://github.com/seek-oss/vanilla-extract/discussions/468 reminded me so I thought I'd give it a go.

I updated TypeScript in this PR because there was a type error that I didn't pick up until it ran in CI because my editor was accidentally using a newer version of TypeScript. Figured it made more sense to upgrade than to figure out why the older version of TypeScript was unhappy.