### PR TITLE
Vite: Mark `.vanilla.js` and `.vanilla.css` modules as virtual.

### DIFF
--- a/.changeset/calm-ravens-sit.md
+++ b/.changeset/calm-ravens-sit.md
@@ -2,4 +2,4 @@
 '@vanilla-extract/vite-plugin': patch
 ---
 
-Prefix `.vanilla.js` and `.vanilla.css` virtual modules with `vanilla-extract:`.
+Prefix `.vanilla.js` and `.vanilla.css` virtual modules with `virtual:vanilla-extract:`.

--- a/.changeset/calm-ravens-sit.md
+++ b/.changeset/calm-ravens-sit.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Prefix `.vanilla.js` and `.vanilla.css` virtual modules with `vanilla-extract:`.

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -66,7 +66,9 @@ export function vanillaExtractPlugin({ identifiers }: Options = {}): Plugin {
       const extensionIndex = id.indexOf(virtualExt);
 
       if (id.startsWith(virtualPrefix) && extensionIndex > 0) {
-        const fileScopeId = id.substring(0, extensionIndex).slice(virtualPrefix.length);
+        const fileScopeId = id
+          .substring(0, extensionIndex)
+          .slice(virtualPrefix.length);
 
         if (!cssMap.has(fileScopeId)) {
           throw new Error(`Unable to locate ${fileScopeId} in the CSS map.`);

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -58,17 +58,16 @@ export function vanillaExtractPlugin({ identifiers }: Options = {}): Plugin {
       packageInfo = getPackageInfo(config.root);
     },
     resolveId(id) {
-      if (id.startsWith(virtualPrefix) && id.indexOf(virtualExt) > 0) {
+      if (id.indexOf(virtualPrefix) === 0) {
         return id;
       }
     },
     load(id) {
-      const extensionIndex = id.indexOf(virtualExt);
-
-      if (id.startsWith(virtualPrefix) && extensionIndex > 0) {
-        const fileScopeId = id
-          .substring(0, extensionIndex)
-          .slice(virtualPrefix.length);
+      if (id.indexOf(virtualPrefix) === 0) {
+        const fileScopeId = id.slice(
+          virtualPrefix.length,
+          id.indexOf(virtualExt),
+        );
 
         if (!cssMap.has(fileScopeId)) {
           throw new Error(`Unable to locate ${fileScopeId} in the CSS map.`);

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -16,6 +16,8 @@ import {
 const styleUpdateEvent = (fileId: string) =>
   `vanilla-extract-style-update:${fileId}`;
 
+const virtualPrefix = 'vanilla-extract:';
+
 interface Options {
   identifiers?: IdentifierOption;
 }
@@ -56,15 +58,15 @@ export function vanillaExtractPlugin({ identifiers }: Options = {}): Plugin {
       packageInfo = getPackageInfo(config.root);
     },
     resolveId(id) {
-      if (id.indexOf(virtualExt) > 0) {
+      if (id.startsWith(virtualPrefix) && id.indexOf(virtualExt) > 0) {
         return id;
       }
     },
     load(id) {
       const extensionIndex = id.indexOf(virtualExt);
 
-      if (extensionIndex > 0) {
-        const fileScopeId = id.substring(0, extensionIndex);
+      if (id.startsWith(virtualPrefix) && extensionIndex > 0) {
+        const fileScopeId = id.substring(0, extensionIndex).slice(virtualPrefix.length);
 
         if (!cssMap.has(fileScopeId)) {
           throw new Error(`Unable to locate ${fileScopeId} in the CSS map.`);
@@ -132,7 +134,7 @@ export function vanillaExtractPlugin({ identifiers }: Options = {}): Plugin {
           identifiers ?? (config.mode === 'production' ? 'short' : 'debug'),
         serializeVirtualCssPath: ({ fileScope, source }) => {
           const fileId = stringifyFileScope(fileScope);
-          const id = `${fileId}${virtualExt}`;
+          const id = `${virtualPrefix}${fileId}${virtualExt}`;
 
           if (server && cssMap.has(fileId) && cssMap.get(fileId) !== source) {
             const { moduleGraph } = server;

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -16,7 +16,7 @@ import {
 const styleUpdateEvent = (fileId: string) =>
   `vanilla-extract-style-update:${fileId}`;
 
-const virtualPrefix = 'vanilla-extract:';
+const virtualPrefix = 'virtual:vanilla-extract:';
 
 interface Options {
   identifiers?: IdentifierOption;


### PR DESCRIPTION
Fixes #427 

Also see a different approach in this PR #457 

### The problem

When used with Vite, if `*.css.ts` module is imported from _outside_ of the root directory, the following error occurs:

```
Unable to locate /path-to.css.ts$$$@scope/package-name in the CSS map.
```

This happens, because the path `../path-to.css.ts` gets overridden to `/../path-to.css.ts` (by `vite:import-analysis`) and then consequently to `/path-to.css.ts` (by `vite.normalizePath`). As a result, `cssMap` stores the source under a different key as it is being retrieved.

This is where the source is stored under `../path-to.css.ts$$$@scope/package-name`:
https://github.com/seek-oss/vanilla-extract/blob/076b02d91f22d0b61df2dd9edd875f86ac4a55ea/packages/vite-plugin/src/index.ts#L152

This is where the we are trying to retrieve the source by wrong key (`/path-to.css.ts$$$@scope/package-name`):
https://github.com/seek-oss/vanilla-extract/blob/076b02d91f22d0b61df2dd9edd875f86ac4a55ea/packages/vite-plugin/src/index.ts#L69

### Solution

This PR should fix the problem, as it prefixes the relative paths with `vanilla-extract:` keyword which preserves the paths.

See [Vite Plugin Conventions](https://vitejs.dev/guide/api-plugin.html#conventions) for `virtual:` prefix.
