### PR TITLE
fix type error on `createTheme/createGlobalTheme` on TypeScript 4.5.0

### DIFF
--- a/packages/css/src/theme.ts
+++ b/packages/css/src/theme.ts
@@ -12,7 +12,7 @@ export function createGlobalTheme<ThemeTokens extends Tokens>(
 export function createGlobalTheme<ThemeContract extends Contract>(
   selector: string,
   themeContract: ThemeContract,
-  tokens: MapLeafNodes<ThemeContract, string>,
+  tokens: MapLeafNodes<Record<keyof ThemeContract, string>, string>,
 ): void;
 export function createGlobalTheme(
   selector: string,
@@ -47,7 +47,7 @@ export function createTheme<ThemeTokens extends Tokens>(
 ): [className: string, vars: ThemeVars<ThemeTokens>];
 export function createTheme<ThemeContract extends Contract>(
   themeContract: ThemeContract,
-  tokens: MapLeafNodes<ThemeContract, string>,
+  tokens: MapLeafNodes<Record<keyof ThemeContract, string>, string>,
   debugId?: string,
 ): string;
 export function createTheme(arg1: any, arg2?: any, arg3?: string): any {


### PR DESCRIPTION
 TypeScript 4.5.0 added ["Template String Types as Discriminants"](discriminants), type `string` is not assignable to type `CSSVarFunction`( `var(--${string})` | `var(--${string}, ${string | number})`) anymore, which caused an type error when use `createTheme/createGlobalTheme` with contract(Here's the [simple reproduction](https://www.typescriptlang.org/play?ts=4.5.0-beta#code/C4TwDgpgBAwgynAagQwE4DECuA7AxsASwHtsoBeKAAwDc0AKAWgYBIBvAZ2FQOwHMBfAJSUoAHyq1UjFhy48BAGihtO3PmKjZMAWwBGEVEMoBuAFChIsEl2T5yUVqajOoAbQDWEEAC4oq+QC6vvBIaFh4hCQaWgA2MRow1qi2wGb8Zubg0ACyyGAAMhDIAGYAckQAJhDsADwA8roAVkqFJQAqWQB89o4ubgAKqERgUDxQniBExVANjUEzTa6DwwFQEAAewBDYFexQAEoQuESoFTX+6uJaegZKyNgg3QD8ULkFRWWV1fWLy2ABLQ+HUg3V8rWKwIgaTMFmgpUwcWQuhiEDaRE82D2FF6Lg8Xl8F1480JGnhiORqPR2z2VwRMWhpkyljRGKxDicuImBLkfGJPN4GhZ1IZGzAJ2AUCquBiaGgsKgbQAFhBtBAUKhakqVRBEtgbHYNlsdnsyTKKULMd0KG9weUqprlardfrgEoQurwvhiNhOhlijgvVFcKgilsAOIxIi6ZAxLWqmpxnVJFJrTbbXZWPXJfCdOjsCAo-AnblqXhKYCOpNZlK+RPO7OuqDAKmY3w2j527515P4JSEzqCXzUIgECoOdKmf0Rb1QYOhiARqMx7vV-AJysWvaG9MmulIlGb3PN1m1jct9iDhWV9UO7WH9nOEPATCoUisfhQZB7e4gBmM+VtNUErWnktpfLU7phAGkTYH2-KdIypjHJiErHJGGo9ByMQELwirAL4OLONGuDuLwQw4BUvgAEQAMQAAwMVRCgcvwzHOBUaDuARHJEbYpHkTs1E0cUIlMSxzETkhJCcFA2hfDe9hzsg4aRtGsaVvWKR0GhJzsAAdNhuHAIIGRKSpS7qdqdAAOSuBxwDIAwFbamQVGGXhVEBNZShyVUN5KDpGoGTheEmUhIbKQuqnLpWNl2cpjnOaqrkcag7ied5snyWg7ABUQ6H6al7gmUAA
)):

<img width="1390" alt="Screen Shot 2021-11-21 at 5 13 38 PM" src="https://user-images.githubusercontent.com/6471705/142756335-e17debd3-6113-4672-b988-56e759d3cd05.png">

This PR fixed this issue by change `tokens` param type in `createTheme/createGlobalTheme` from `MapLeafNodes<ThemeContract, string>` to `MapLeafNodes<Record<keyof ThemeContract, string>, string>`

fixes #483
fixes #484

