### PR TITLE
Fix theme contract types in TypeScript 4.5

### DIFF
--- a/.changeset/tiny-brooms-guess.md
+++ b/.changeset/tiny-brooms-guess.md
@@ -1,0 +1,6 @@
+---
+'@vanilla-extract/css': patch
+'@vanilla-extract/private': patch
+---
+
+Fix theme contract types in TypeScript 4.5

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "jest": "^26.6.3",
     "prettier": "^2.3.2",
     "ts-node": "^9.1.1",
-    "typescript": "^4.1.3"
+    "typescript": "^4.5.0"
   }
 }

--- a/packages/css/src/vars.ts
+++ b/packages/css/src/vars.ts
@@ -73,6 +73,8 @@ export function assignVars<VarContract extends Contract>(
 export function createThemeContract<ThemeTokens extends NullableTokens>(
   tokens: ThemeTokens,
 ): ThemeVars<ThemeTokens> {
+  // TS is giving type impossibly deep error here. Ignoring for now as this shouldn't affect consumers.
+  // @ts-expect-error
   return walkObject(tokens, (_value, path) => {
     return createVar(path.join('-'));
   });

--- a/packages/private/src/types.ts
+++ b/packages/private/src/types.ts
@@ -6,8 +6,12 @@ export type Contract = {
   [key: string]: CSSVarFunction | null | Contract;
 };
 
+type Primitive = string | boolean | number | null | undefined;
+
 export type MapLeafNodes<Obj, LeafType> = {
-  [Prop in keyof Obj]: Obj[Prop] extends Record<string | number, any>
+  [Prop in keyof Obj]: Obj[Prop] extends Primitive
+    ? LeafType
+    : Obj[Prop] extends Record<string | number, any>
     ? MapLeafNodes<Obj[Prop], LeafType>
-    : LeafType;
+    : never;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -16863,23 +16863,23 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-typescript@^4.1.3:
-  version: 4.2.3
-  resolution: "typescript@npm:4.2.3"
+"typescript@npm:^4.5.0":
+  version: 4.5.2
+  resolution: "typescript@npm:4.5.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: b4a2020c021211184ac15caf59936b2089c13e79685f340a31aaa839c9de2f73b44a5e3757292de6cdad2ed967aef80d4592161b814cc29c0570f261850c4bca
+  checksum: 74f9ce65d532bdf5d0214b3f60cf37992180023388c87a11ee6f838a803067ef0b63c600fa501b0deb07f989257dce1e244c9635ed79feca40bbccf6e0aa1ebc
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.1.3#~builtin<compat/typescript>":
-  version: 4.2.3
-  resolution: "typescript@patch:typescript@npm%3A4.2.3#~builtin<compat/typescript>::version=4.2.3&hash=ddd1e8"
+"typescript@patch:typescript@^4.5.0#~builtin<compat/typescript>":
+  version: 4.5.2
+  resolution: "typescript@patch:typescript@npm%3A4.5.2#~builtin<compat/typescript>::version=4.5.2&hash=ddd1e8"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: f97b1f885444f13c340127a0918b17d0c4e5c248f99203a22712b3b43d7129c9c7b95437e4f1de99edf79d3046fa9e15356fb5d27d9d94e47a98158c8b18fda5
+  checksum: 24a439e062a05e3285a4f0e8a40644116ecdca89f3e908bed01e5a01b9aee747e3bcf0e85fe9e017e5ebf0c0863437c39479f2616f55a244c2d82d37022cdc4f
   languageName: node
   linkType: hard
 
@@ -17498,7 +17498,7 @@ typescript@^4.1.3:
     jest: ^26.6.3
     prettier: ^2.3.2
     ts-node: ^9.1.1
-    typescript: ^4.1.3
+    typescript: ^4.5.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Not sure what TypeScript 4.5 is smoking but it seems to think that [template strings are records now](https://www.typescriptlang.org/play?ts=4.5.0-beta#code/C4TwDgpgBAKhC2YA2BDYEDKwBOBLAdgOZQC8UABgG4rYAUAtPQCQDeAzjgYQL4CU5AKFCQoAOQD22eCiRY8RUlADkbcfAj1qSAK4QlAoeGgBBfAHkARgCsIAY2CKASnckATADwd5xAD5R82vAWENgANFAo+CAAfADcBsIminCIqOhyXFAQAB7o+K5sUKaWNvZQAPzKAOowAGJKUABcymYA1iggSvGJUABCihJSMhkKOXkFRebWdg6VSjX1TS3tnbFAA)? I personally think this might be a TS bug but we can work around it.

Resolves #484
Resolves #483 