### PR TITLE
Fix version script for yarn 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "format": "prettier --write .",
     "lint": "manypkg check && prettier --check . && tsc",
     "copy-readme-to-packages": "ts-node scripts/copy-readme-to-packages",
-    "version": "changeset version && yarn",
+    "version": "changeset version && yarn --mode=update-lockfile",
     "release": "yarn copy-readme-to-packages && yarn build && changeset publish"
   },
   "workspaces": [


### PR DESCRIPTION
Yarn 3 infers the `--immutable` flag in CI environments. This prevents the version command from updating the lockfile for the version packages PR.