### PR TITLE
Don't ignore tests

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,11 +11,5 @@
   "updateInternalDependencies": "patch",
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
-  },
-  "ignore": [
-    "@fixtures/*",
-    "test-helpers",
-    "vanilla-extract-example-next",
-    "vanilla-extract-example-webpack-react"
-  ]
+  }
 }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -15,7 +15,6 @@
   "ignore": [
     "@fixtures/*",
     "test-helpers",
-    "tests",
     "vanilla-extract-example-next",
     "vanilla-extract-example-webpack-react"
   ]


### PR DESCRIPTION
Tests are a workspace now, which means that `"private": true` takes care of ignoring them.