### PR TITLE
Add `exports` field to packages with multiple entrypoints

### DIFF
--- a/.changeset/grumpy-carrots-arrive.md
+++ b/.changeset/grumpy-carrots-arrive.md
@@ -1,0 +1,9 @@
+---
+'@vanilla-extract/css': patch
+'@vanilla-extract/dynamic': patch
+'@vanilla-extract/recipes': patch
+'@vanilla-extract/sprinkles': patch
+'@vanilla-extract/webpack-plugin': patch
+---
+
+Add `exports` field to `package.json` so nested package paths can be imported in a Node.js ESM context

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -9,6 +9,73 @@
     "./dist/vanilla-extract-css.cjs.js": "./dist/vanilla-extract-css.browser.cjs.js",
     "./dist/vanilla-extract-css.esm.js": "./dist/vanilla-extract-css.browser.esm.js"
   },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "browser": {
+        "module": "./dist/vanilla-extract-css.browser.esm.js",
+        "default": "./dist/vanilla-extract-css.browser.cjs.js"
+      },
+      "module": "./dist/vanilla-extract-css.esm.js",
+      "default": "./dist/vanilla-extract-css.cjs.js"
+    },
+    "./recipe": {
+      "browser": {
+        "module": "./recipe/dist/vanilla-extract-css-recipe.browser.esm.js",
+        "default": "./recipe/dist/vanilla-extract-css-recipe.browser.cjs.js"
+      },
+      "module": "./recipe/dist/vanilla-extract-css-recipe.esm.js",
+      "default": "./recipe/dist/vanilla-extract-css-recipe.cjs.js"
+    },
+    "./functionSerializer": {
+      "browser": {
+        "module": "./functionSerializer/dist/vanilla-extract-css-functionSerializer.browser.esm.js",
+        "default": "./functionSerializer/dist/vanilla-extract-css-functionSerializer.browser.cjs.js"
+      },
+      "module": "./functionSerializer/dist/vanilla-extract-css-functionSerializer.esm.js",
+      "default": "./functionSerializer/dist/vanilla-extract-css-functionSerializer.cjs.js"
+    },
+    "./adapter": {
+      "browser": {
+        "module": "./adapter/dist/vanilla-extract-css-adapter.browser.esm.js",
+        "default": "./adapter/dist/vanilla-extract-css-adapter.browser.cjs.js"
+      },
+      "module": "./adapter/dist/vanilla-extract-css-adapter.esm.js",
+      "default": "./adapter/dist/vanilla-extract-css-adapter.cjs.js"
+    },
+    "./transformCss": {
+      "browser": {
+        "module": "./transformCss/dist/vanilla-extract-css-transformCss.browser.esm.js",
+        "default": "./transformCss/dist/vanilla-extract-css-transformCss.browser.cjs.js"
+      },
+      "module": "./transformCss/dist/vanilla-extract-css-transformCss.esm.js",
+      "default": "./transformCss/dist/vanilla-extract-css-transformCss.cjs.js"
+    },
+    "./fileScope": {
+      "browser": {
+        "module": "./fileScope/dist/vanilla-extract-css-fileScope.browser.esm.js",
+        "default": "./fileScope/dist/vanilla-extract-css-fileScope.browser.cjs.js"
+      },
+      "module": "./fileScope/dist/vanilla-extract-css-fileScope.esm.js",
+      "default": "./fileScope/dist/vanilla-extract-css-fileScope.cjs.js"
+    },
+    "./injectStyles": {
+      "browser": {
+        "module": "./injectStyles/dist/vanilla-extract-css-injectStyles.browser.esm.js",
+        "default": "./injectStyles/dist/vanilla-extract-css-injectStyles.browser.cjs.js"
+      },
+      "module": "./injectStyles/dist/vanilla-extract-css-injectStyles.esm.js",
+      "default": "./injectStyles/dist/vanilla-extract-css-injectStyles.cjs.js"
+    },
+    "./disableRuntimeStyles": {
+      "browser": {
+        "module": "./disableRuntimeStyles/dist/vanilla-extract-css-disableRuntimeStyles.browser.esm.js",
+        "default": "./disableRuntimeStyles/dist/vanilla-extract-css-disableRuntimeStyles.browser.cjs.js"
+      },
+      "module": "./disableRuntimeStyles/dist/vanilla-extract-css-disableRuntimeStyles.esm.js",
+      "default": "./disableRuntimeStyles/dist/vanilla-extract-css-disableRuntimeStyles.cjs.js"
+    }
+  },
   "preconstruct": {
     "entrypoints": [
       "index.ts",

--- a/packages/dynamic/package.json
+++ b/packages/dynamic/package.json
@@ -5,6 +5,13 @@
   "sideEffects": false,
   "main": "dist/vanilla-extract-dynamic.cjs.js",
   "module": "dist/vanilla-extract-dynamic.esm.js",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "module": "./dist/vanilla-extract-dynamic.esm.js",
+      "default": "./dist/vanilla-extract-dynamic.cjs.js"
+    }
+  },
   "files": [
     "/dist"
   ],

--- a/packages/recipes/package.json
+++ b/packages/recipes/package.json
@@ -5,6 +5,17 @@
   "sideEffects": false,
   "main": "dist/vanilla-extract-recipes.cjs.js",
   "module": "dist/vanilla-extract-recipes.esm.js",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "module": "./dist/vanilla-extract-recipes.esm.js",
+      "default": "./dist/vanilla-extract-recipes.cjs.js"
+    },
+    "./createRuntimeFn": {
+      "module": "./createRuntimeFn/dist/vanilla-extract-recipes-createRuntimeFn.esm.js",
+      "default": "./createRuntimeFn/dist/vanilla-extract-recipes-createRuntimeFn.cjs.js"
+    }
+  },
   "files": [
     "/dist",
     "/createRuntimeFn"

--- a/packages/sprinkles/package.json
+++ b/packages/sprinkles/package.json
@@ -5,6 +5,21 @@
   "sideEffects": false,
   "main": "dist/vanilla-extract-sprinkles.cjs.js",
   "module": "dist/vanilla-extract-sprinkles.esm.js",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "module": "./dist/vanilla-extract-sprinkles.esm.js",
+      "default": "./dist/vanilla-extract-sprinkles.cjs.js"
+    },
+    "./createRuntimeSprinkles": {
+      "module": "./createRuntimeSprinkles/dist/vanilla-extract-sprinkles-createRuntimeSprinkles.esm.js",
+      "default": "./createRuntimeSprinkles/dist/vanilla-extract-sprinkles-createRuntimeSprinkles.cjs.js"
+    },
+    "./createUtils": {
+      "module": "./createUtils/dist/vanilla-extract-sprinkles-createUtils.esm.js",
+      "default": "./createUtils/dist/vanilla-extract-sprinkles-createUtils.cjs.js"
+    }
+  },
   "files": [
     "/dist",
     "/createRuntimeSprinkles",

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -4,6 +4,21 @@
   "description": "Zero-runtime Stylesheets-in-TypeScript",
   "main": "dist/vanilla-extract-webpack-plugin.cjs.js",
   "module": "dist/vanilla-extract-webpack-plugin.esm.js",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "module": "./dist/vanilla-extract-webpack-plugin.esm.js",
+      "default": "./dist/vanilla-extract-webpack-plugin.cjs.js"
+    },
+    "./loader": {
+      "module": "./loader/dist/vanilla-extract-webpack-plugin-loader.esm.js",
+      "default": "./loader/dist/vanilla-extract-webpack-plugin-loader.cjs.js"
+    },
+    "./extracted": {
+      "module": "./extracted/dist/vanilla-extract-webpack-plugin-extracted.esm.js",
+      "default": "./extracted/dist/vanilla-extract-webpack-plugin-extracted.cjs.js"
+    }
+  },
   "preconstruct": {
     "entrypoints": [
       "index.ts",


### PR DESCRIPTION
Fixes the following issue: https://github.com/markdalgleish/preconstruct-node-esm-import-issue. To see the fix working, you can run this repro locally and manually apply the diff seen in this PR to `node_modules/@vanilla-extract/sprinkles/package.json`.

Related issue on Preconstruct: https://github.com/preconstruct/preconstruct/issues/432

More detail about the `exports` field and its conditional syntax: https://webpack.js.org/guides/package-exports

I ran into this issue because the Sprinkles runtime was being consumed within an ESM package (i.e. `"type": "module"`) and Node.js doesn't allow directory imports in ESM mode. Instead, all nested import paths need to be explicitly defined in the `exports` field.