### PR TITLE
Provide example of how to have multiple declarations for same property for fallbacks

### DIFF
--- a/site/docs/styling-api.md
+++ b/site/docs/styling-api.md
@@ -28,6 +28,7 @@ import { vars } from './vars.css.ts';
 
 export const className = style({
   display: 'flex',
+  minHeight: ['100vh', '-webkit-fill-available'],
   vars: {
     [vars.localVar]: 'green',
     '--global-variable': 'purple'


### PR DESCRIPTION
I've added an example to the Styles API docs showing how you can have fallback values for a property. Could not find mention of this functionality in the docs anywhere else, but was mentioned [in this discussion](https://github.com/seek-oss/vanilla-extract/discussions/481).

My example shows how

```
minHeight: ['100vh', '-webkit-fill-available']
```

becomes

```css
min-height: 100vh;
min-height: -webkit-fill-available;
```

For reference, this example fallback is used as part of [a little hack to get full height pages in mobile Safari](https://css-tricks.com/css-fix-for-100vh-in-mobile-webkit/).