### PR TITLE
Ensure code is compatible with node 12

### DIFF
--- a/.changeset/odd-suits-call.md
+++ b/.changeset/odd-suits-call.md
@@ -1,0 +1,10 @@
+---
+'@vanilla-extract/babel-plugin': patch
+'@vanilla-extract/esbuild-plugin': patch
+'@vanilla-extract/integration': patch
+'@vanilla-extract/next-plugin': patch
+'@vanilla-extract/vite-plugin': patch
+'@vanilla-extract/webpack-plugin': patch
+---
+
+Ensure code is compatible with node 12

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,9 @@
 module.exports = {
-  presets: ['@babel/preset-typescript', '@babel/preset-react'],
+  presets: [
+    ['@babel/preset-env', { targets: { node: 12 } }],
+    '@babel/preset-typescript',
+    '@babel/preset-react',
+  ],
 
   overrides: [
     {


### PR DESCRIPTION
When we started transpiling the browser based packages correctly, we stopped transpiling down to node 12 features for the node based packages.

There is a known issue with the webpack-plugin. Not sure about the other ones but will release just in case.