### PR TITLE
vite: Sanitise virtual import path characters

### DIFF
--- a/.changeset/sour-years-push.md
+++ b/.changeset/sour-years-push.md
@@ -1,0 +1,6 @@
+---
+'@vanilla-extract/integration': patch
+'@vanilla-extract/vite-plugin': patch
+---
+
+Sanitise virtual import path characters

--- a/packages/integration/src/processVanillaFile.ts
+++ b/packages/integration/src/processVanillaFile.ts
@@ -15,7 +15,9 @@ export function stringifyFileScope({
   packageName,
   filePath,
 }: FileScope): string {
-  return packageName ? `${filePath}$$$${packageName}` : filePath;
+  const fileScope = packageName ? `${filePath}$$$${packageName}` : filePath;
+  // This file id is requested through a URL where "/", "\" and ".." isn't valid.
+  return fileScope.replace(/(\|\/|\.\.)/, '_');
 }
 
 export function parseFileScope(serialisedFileScope: string): FileScope {

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -148,11 +148,7 @@ export function vanillaExtractPlugin({ identifiers }: Options = {}): Plugin {
         identOption:
           identifiers ?? (config.mode === 'production' ? 'short' : 'debug'),
         serializeVirtualCssPath: async ({ fileScope, source }) => {
-          // This file id is requested through a URL where ".." isn't valid.
-          const fileId = stringifyFileScope(fileScope).replace(
-            /\.\./g,
-            '_dir_up_',
-          );
+          const fileId = stringifyFileScope(fileScope);
           const id = `${virtualPrefix}${fileId}${virtualExt}`;
 
           let cssSource = source;


### PR DESCRIPTION
fixes: #631 

Speaking with @graup this issue also occurs in the file path, when you have multiple style files called the same thing, for example `component1/style.css.ts` and `component2/style.css.ts`. So this sanitises both by replacing slashes and double dots with underscores. I moved the double dot fix from the last release up to `stringifyFileScope` as part of this.