### PR TITLE
integration: Fix __webpack_require__ is not defined error

### DIFF
--- a/.changeset/cold-bags-jump.md
+++ b/.changeset/cold-bags-jump.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/integration': patch
+---
+
+Fix "\_\_webpack_require\_\_ is not defined" error

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@vanilla-extract/css": "^1.6.8",
     "esbuild": "^0.11.16",
-    "eval": "^0.1.6",
+    "eval": "0.1.6",
     "find-up": "^5.0.0",
     "javascript-stringify": "^2.0.1",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,7 +212,7 @@ importers:
       '@types/lodash': ^4.14.168
       '@vanilla-extract/css': ^1.6.8
       esbuild: ^0.11.16
-      eval: ^0.1.6
+      eval: 0.1.6
       find-up: ^5.0.0
       javascript-stringify: ^2.0.1
       lodash: ^4.17.21


### PR DESCRIPTION
Pinning the `eval` dependency on the `@vanilla-extract/integration` package as a quick fix for #637 

Fixes https://github.com/seek-oss/vanilla-extract/issues/637