### PR TITLE
Bump "integration" package

### DIFF
--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -22,6 +22,6 @@
   "dependencies": {
     "@babel/core": "^7.13.10",
     "@babel/template": "^7.12.13",
-    "@vanilla-extract/integration": "^3.0.0"
+    "@vanilla-extract/integration": "^3.0.1"
   }
 }


### PR DESCRIPTION
Following this thread
https://github.com/seek-oss/vanilla-extract/issues/637#issuecomment-1083259372

it seems like bumping `integration` dep version will fix `webpack_require` issue