### PR TITLE
feat: validate media queries

### DIFF
--- a/.changeset/moody-poems-tan.md
+++ b/.changeset/moody-poems-tan.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/css': minor
+---
+
+Add CSS media query validation

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -110,6 +110,7 @@
     "@emotion/hash": "^0.8.0",
     "@vanilla-extract/private": "^1.0.3",
     "chalk": "^4.1.1",
+    "css-mediaquery": "^0.1.2",
     "css-what": "^5.0.1",
     "cssesc": "^3.0.0",
     "csstype": "^3.0.7",
@@ -119,6 +120,7 @@
     "outdent": "^0.8.0"
   },
   "devDependencies": {
+    "@types/css-mediaquery": "^0.1.1",
     "@types/cssesc": "^3.0.0"
   }
 }

--- a/packages/css/src/transformCss.ts
+++ b/packages/css/src/transformCss.ts
@@ -20,6 +20,7 @@ import { forEach, omit, mapKeys } from './utils';
 import { validateSelector } from './validateSelector';
 import { ConditionalRuleset } from './conditionalRulesets';
 import { simplePseudos, simplePseudoLookup } from './simplePseudos';
+import { validateMediaQuery } from './validateMediaQuery';
 
 const UNITLESS: Record<string, boolean> = {
   animationIterationCount: true,
@@ -328,6 +329,8 @@ class Stylesheet {
       );
 
       forEach(rules, (mediaRule, query) => {
+        validateMediaQuery(query);
+
         const conditions = [...parentConditions, `@media ${query}`];
 
         this.addConditionalRule(

--- a/packages/css/src/validateMediaQuery.test.ts
+++ b/packages/css/src/validateMediaQuery.test.ts
@@ -1,0 +1,36 @@
+import { validateMediaQuery } from './validateMediaQuery';
+
+describe('validateMediaQuery', () => {
+  describe('valid selectors', () => {
+    const validMediaQueries = [
+      'screen',
+      'screen, print',
+      'screen and (max-width: 600px)',
+      '(min-width: 5rem)',
+      '(min-width: 30em) and (orientation: landscape)',
+      'only screen and (min-width: 320px) and (max-width: 480px) and (resolution: 150dpi)',
+      'not screen and (color), print and (color)',
+    ];
+
+    validMediaQueries.forEach((query) =>
+      it(query, () => {
+        expect(() => validateMediaQuery(query)).not.toThrow();
+      }),
+    );
+  });
+
+  describe('invalid media queries', () => {
+    const invalidMediaQueries = [
+      '',
+      'random query',
+      '(min-height: 600px',
+      'min-width: 600px)',
+    ];
+
+    invalidMediaQueries.forEach((query) =>
+      it(query, () => {
+        expect(() => validateMediaQuery(query)).toThrow();
+      }),
+    );
+  });
+});

--- a/packages/css/src/validateMediaQuery.ts
+++ b/packages/css/src/validateMediaQuery.ts
@@ -1,0 +1,25 @@
+import outdent from 'outdent';
+import { parse } from 'css-mediaquery';
+
+const mediaTypes = ['all', 'print', 'screen'];
+
+export const validateMediaQuery = (mediaQuery: string) => {
+  const { type, expressions } = parse(mediaQuery)?.[0];
+
+  const isAllQuery = mediaQuery === 'all';
+  const isValidType = mediaTypes.includes(type);
+
+  // If the parser returns all for the type, we should have expressions
+  // or the query should match 'all' otherwise it is invalid
+  if (!isValidType || (!isAllQuery && type === 'all' && !expressions.length)) {
+    throw new Error(
+      outdent`
+      Invalid media query: ${mediaQuery}
+
+      A media query can contain an optional media type and any number of media feature expressions.
+  
+      Read more on MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries
+    `,
+    );
+  }
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,9 +165,11 @@ importers:
   packages/css:
     specifiers:
       '@emotion/hash': ^0.8.0
+      '@types/css-mediaquery': ^0.1.1
       '@types/cssesc': ^3.0.0
       '@vanilla-extract/private': ^1.0.3
       chalk: ^4.1.1
+      css-mediaquery: ^0.1.2
       css-what: ^5.0.1
       cssesc: ^3.0.0
       csstype: ^3.0.7
@@ -179,6 +181,7 @@ importers:
       '@emotion/hash': 0.8.0
       '@vanilla-extract/private': link:../private
       chalk: 4.1.2
+      css-mediaquery: 0.1.2
       css-what: 5.1.0
       cssesc: 3.0.0
       csstype: 3.0.10
@@ -187,6 +190,7 @@ importers:
       escape-string-regexp: 4.0.0
       outdent: 0.8.0
     devDependencies:
+      '@types/css-mediaquery': 0.1.1
       '@types/cssesc': 3.0.0
 
   packages/dynamic:
@@ -2917,6 +2921,10 @@ packages:
       '@types/node': 16.11.10
     dev: false
 
+  /@types/css-mediaquery/0.1.1:
+    resolution: {integrity: sha512-JQ+sPiPlRUHmlL4e3DBUNbxVEb6p7dis78/uSDbQpkeCKVoepChZMWGPIVA2JIH0ylfkA9S+TZUdShlgDpFKrw==}
+    dev: true
+
   /@types/cssesc/3.0.0:
     resolution: {integrity: sha512-4mBnOrTpVKn+tYzlnMO7cwDkDa6wlQ2bBXW+79/6ahMd36GF216kxWYxgz+S4d5Ev1ByFbnQbPGxV4P5BSL8MA==}
     dev: true
@@ -4789,6 +4797,10 @@ packages:
       schema-utils: 3.1.1
       semver: 7.3.5
       webpack: 5.64.2_93fbbb02a3bda170b039a49a61f47e0a
+
+  /css-mediaquery/0.1.2:
+    resolution: {integrity: sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA=}
+    dev: false
 
   /css-select/4.1.3:
     resolution: {integrity: sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==}


### PR DESCRIPTION
This PR adds some basic CSS media query linting (see: https://github.com/seek-oss/vanilla-extract/discussions/480).

At work, we've shipped a couple of bugs because an invalid media query wasn't caught during code review (eg. `@media (max-width: 600px`). CSSType doesn't catch this, nor does Vanilla Extract. It [looks like CSSType might tackle it in the future](https://github.com/frenic/csstype/issues/66#issuecomment-1004090875).

I wanted to see if I could put something quick together this weekend so this is that attempt. I also tried doing a RegEx attempt but that ended up getting pretty unwieldy (similar to this: https://github.com/niksy/regex-css-media-query).

Would love to hear if you had any ideas on how to tackle this!