### PR TITLE
Fix fontFamily since it changed in the CSS file

### DIFF
--- a/site/src/themes.css.ts
+++ b/site/src/themes.css.ts
@@ -155,7 +155,7 @@ export const vars = createGlobalTheme(':root', {
     heading:
       '"DM Sans", "Helvetica Neue", HelveticaNeue, Helvetica, sans-serif',
     body: '-apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", HelveticaNeue, Helvetica, Arial, sans-serif',
-    code: 'MonoLisa, "Roboto Mono", Menlo, monospace',
+    code: 'ml, "Roboto Mono", Menlo, monospace',
   },
   grid: px(grid),
   spacing: {


### PR DESCRIPTION
The CSS endpoint now generates `ml` instead of `MonoLisa` to avoid conflicts with local fonts