### PR TITLE
Replace __dirname and __filename in .css.ts file source

### DIFF
--- a/.changeset/grumpy-feet-listen.md
+++ b/.changeset/grumpy-feet-listen.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/integration': patch
+---
+
+Replace **dirname and **filename in .css.ts file source

--- a/packages/integration/src/compile.ts
+++ b/packages/integration/src/compile.ts
@@ -60,7 +60,12 @@ export async function compile({
   }
 
   return {
-    source: outputFiles[0].text,
+    source: outputFiles[0].text
+      .replace(new RegExp('__' + 'filename', 'g'), JSON.stringify(filePath))
+      .replace(
+        new RegExp('__' + 'dirname', 'g'),
+        JSON.stringify(dirname(filePath)),
+      ),
     watchFiles: Object.keys(metafile?.inputs || {}).map((filePath) =>
       join(cwd, filePath),
     ),


### PR DESCRIPTION
Allows `__filename` and `__dirname` to be used in `.css.ts` files. Resolving this repro:  https://github.com/AndrewLeedham/vanilla-extract-filename

It uses a somewhat naive approach of regex replacement since that is what Vite does. The `'__' + 'filename'` instead of just `'__filename'` is intended to prevent Vite from replacing the replacement when using the plugin 🙄 