### PR TITLE
Fix rollup plugin tests and docs for preserve modules with adjusted asset names

### DIFF
--- a/packages/rollup-plugin/test/__snapshots__/rollup-plugin.test.ts.snap
+++ b/packages/rollup-plugin/test/__snapshots__/rollup-plugin.test.ts.snap
@@ -250,12 +250,12 @@ export { altButton, altContainer, testNodes as default, dynamicVarsButton, dynam
 exports[`rollup-plugin should build with preserveModules and assetFileNames 1`] = `
 Array [
   Array [
-    "src/index.js",
+    "index.js",
     "import { assignInlineVars, setElementVars } from '@vanilla-extract/dynamic';
 import { vars, altTheme, theme, responsiveTheme } from './themes.css.js';
 import { container, button, opacity } from './styles.css.js';
 import { shadow } from './shared.css.js';
-import testNodes from '../test-nodes.json.js';
+import testNodes from './test-nodes.json.js';
 
 const inlineTheme = assignInlineVars(vars, {
   colors: {
@@ -332,7 +332,7 @@ render();
 ",
   ],
   Array [
-    "src/shared.css.js",
+    "shared.css.js",
     "import './shared.css.ts.vanilla.css';
 
 var shadow = \\"shared__4dtfen0\\";
@@ -341,7 +341,7 @@ export { shadow };
 ",
   ],
   Array [
-    "src/shared.css.ts.vanilla.css",
+    "shared.css.ts.vanilla.css",
     ".shared__4dtfen0 {
   box-shadow: 0 0 5px red;
 }
@@ -350,7 +350,7 @@ body {
 }",
   ],
   Array [
-    "src/styles.css.js",
+    "styles.css.js",
     "import './shared.css.ts.vanilla.css';
 import './themes.css.ts.vanilla.css';
 import './styles.css.ts.vanilla.css';
@@ -363,7 +363,7 @@ export { button, container, opacity };
 ",
   ],
   Array [
-    "src/styles.css.ts.vanilla.css",
+    "styles.css.ts.vanilla.css",
     "@font-face {
   src: local(\\"Impact\\");
   font-family: \\"styles__jteyb10\\";
@@ -416,48 +416,6 @@ html .styles_1\\\\/4__jteyb17 {
 }",
   ],
   Array [
-    "src/themes.css.js",
-    "import './themes.css.ts.vanilla.css';
-
-var altTheme = \\"themes__cvta176\\";
-var responsiveTheme = \\"themes__cvta177\\";
-var theme = \\"themes__cvta170\\";
-var vars = {colors: {backgroundColor: \\"var(--colors-backgroundColor__cvta171)\\", text: \\"var(--colors-text__cvta172)\\"}, space: {\\"1\\": \\"var(--space-1__cvta173)\\", \\"2\\": \\"var(--space-2__cvta174)\\", \\"3\\": \\"var(--space-3__cvta175)\\"}};
-
-export { altTheme, responsiveTheme, theme, vars };
-",
-  ],
-  Array [
-    "src/themes.css.ts.vanilla.css",
-    ":root, .themes__cvta170 {
-  --colors-backgroundColor__cvta171: blue;
-  --colors-text__cvta172: white;
-  --space-1__cvta173: 4px;
-  --space-2__cvta174: 8px;
-  --space-3__cvta175: 12px;
-}
-.themes__cvta176 {
-  --colors-backgroundColor__cvta171: green;
-  --colors-text__cvta172: white;
-  --space-1__cvta173: 8px;
-  --space-2__cvta174: 12px;
-  --space-3__cvta175: 16px;
-}
-.themes__cvta177 {
-  --colors-backgroundColor__cvta171: pink;
-  --colors-text__cvta172: purple;
-  --space-1__cvta173: 6px;
-  --space-2__cvta174: 12px;
-  --space-3__cvta175: 18px;
-}
-@media screen and (min-width: 768px) {
-  .themes__cvta177 {
-    --colors-backgroundColor__cvta171: purple;
-    --colors-text__cvta172: pink;
-  }
-}",
-  ],
-  Array [
     "test-nodes.json.js",
     "var root = \\"root\\";
 var rootContainer = \\"rootContainer\\";
@@ -490,6 +448,48 @@ var testNodes = {
 
 export { altButton, altContainer, testNodes as default, dynamicVarsButton, dynamicVarsContainer, inlineThemeButton, inlineThemeContainer, nestedRootButton, nestedRootContainer, responsiveThemeButton, responsiveThemeContainer, root, rootButton, rootContainer };
 ",
+  ],
+  Array [
+    "themes.css.js",
+    "import './themes.css.ts.vanilla.css';
+
+var altTheme = \\"themes__cvta176\\";
+var responsiveTheme = \\"themes__cvta177\\";
+var theme = \\"themes__cvta170\\";
+var vars = {colors: {backgroundColor: \\"var(--colors-backgroundColor__cvta171)\\", text: \\"var(--colors-text__cvta172)\\"}, space: {\\"1\\": \\"var(--space-1__cvta173)\\", \\"2\\": \\"var(--space-2__cvta174)\\", \\"3\\": \\"var(--space-3__cvta175)\\"}};
+
+export { altTheme, responsiveTheme, theme, vars };
+",
+  ],
+  Array [
+    "themes.css.ts.vanilla.css",
+    ":root, .themes__cvta170 {
+  --colors-backgroundColor__cvta171: blue;
+  --colors-text__cvta172: white;
+  --space-1__cvta173: 4px;
+  --space-2__cvta174: 8px;
+  --space-3__cvta175: 12px;
+}
+.themes__cvta176 {
+  --colors-backgroundColor__cvta171: green;
+  --colors-text__cvta172: white;
+  --space-1__cvta173: 8px;
+  --space-2__cvta174: 12px;
+  --space-3__cvta175: 16px;
+}
+.themes__cvta177 {
+  --colors-backgroundColor__cvta171: pink;
+  --colors-text__cvta172: purple;
+  --space-1__cvta173: 6px;
+  --space-2__cvta174: 12px;
+  --space-3__cvta175: 18px;
+}
+@media screen and (min-width: 768px) {
+  .themes__cvta177 {
+    --colors-backgroundColor__cvta171: purple;
+    --colors-text__cvta172: pink;
+  }
+}",
   ],
 ]
 `;

--- a/packages/rollup-plugin/test/rollup-plugin.test.ts
+++ b/packages/rollup-plugin/test/rollup-plugin.test.ts
@@ -51,8 +51,9 @@ describe('rollup-plugin', () => {
     await buildAndMatchSnapshot({
       format: 'esm',
       preserveModules: true,
+      preserveModulesRoot: path.dirname(require.resolve('@fixtures/themed')),
       assetFileNames({ name }) {
-        return name?.replace(/^@fixtures\/themed\/src\//, '') ?? '';
+        return name?.replace(/^src\//, '') ?? '';
       },
     });
   });

--- a/site/docs/setup.md
+++ b/site/docs/setup.md
@@ -262,12 +262,12 @@ This plugin works well with Rollup's `preserveModules`.
 
 Rollup by default places assets in an "assets" directory.
 You can configure [asset file names](https://rollupjs.org/guide/en/#outputassetfilenames)
-if you care about CSS assets being placed right next to source files.
+if you care about CSS assets being placed right next to the corresponding JS files.
 
 ```js
   preserveModules: true,
   assetFileNames({ name }) {
-    return name.replace(/^package-name\/src/, '');
+    return name?.replace(/^src\//, '') ?? '';
   },
 ```
 


### PR DESCRIPTION
- The package name is not needed anymore after https://github.com/seek-oss/vanilla-extract/pull/673
- The test actually wasn't testing what I intended (preserving modules with correct paths for both JS and CSS – `preserveModuelsRoot` is normally not required but required here because of the way the fixture is referenced)

This has no effect on any published package code, so I didn't add a changeset.