### PR TITLE
rollup: clear emitted files cache for watch mode

### DIFF
--- a/.changeset/slow-turkeys-shout.md
+++ b/.changeset/slow-turkeys-shout.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/rollup-plugin': minor
+---
+
+Fix emitting assets when in watch mode

--- a/.changeset/slow-turkeys-shout.md
+++ b/.changeset/slow-turkeys-shout.md
@@ -1,5 +1,5 @@
 ---
-'@vanilla-extract/rollup-plugin': minor
+'@vanilla-extract/rollup-plugin': patch
 ---
 
 Fix emitting assets when in watch mode

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -22,6 +22,9 @@ export function vanillaExtractPlugin({
 
   return {
     name: 'vanilla-extract',
+    buildStart() {
+      emittedFiles.clear();
+    },
     async transform(_code, id) {
       if (!cssFileFilter.test(id)) {
         return null;


### PR DESCRIPTION
Fixes #691

The issue was that `emittedFiles` still held references to the assets from the previous build. Those are accessed down below at `if (!emittedFiles.get(fileName))`. However, assets get cleared on a re-build, so we need to re-emit those files when we're in watch mode.

I wish I could write a test for this but I have no idea how to simulate rollup watch mode and file changes :/