### PR TITLE
fix(vite-plugin): return css in production

### DIFF
--- a/.changeset/fuzzy-flowers-fold.md
+++ b/.changeset/fuzzy-flowers-fold.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Generate CSS and not HMR code if vite server is present in production mode

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -96,7 +96,7 @@ export function vanillaExtractPlugin({
         return;
       }
 
-      if (!server) {
+      if (!server || server.config.isProduction) {
         return css;
       }
 


### PR DESCRIPTION
In the event of a dev server being present, currently this is treated as though we're in dev mode. But in some cases (as in Nuxt's) the server is present in the build process and we can detect this by looking to see whether `isProduction` is set.

resolves #445, resolves #446