### PR TITLE
Support React Server Components in Vite plugin and fix HMR

### DIFF
--- a/.changeset/silly-yaks-whisper.md
+++ b/.changeset/silly-yaks-whisper.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': minor
+---
+
+Add [experimental support for React Server Components](https://github.com/facebook/react/pull/22952)

--- a/.changeset/soft-lobsters-promise.md
+++ b/.changeset/soft-lobsters-promise.md
@@ -2,4 +2,4 @@
 '@vanilla-extract/vite-plugin': patch
 ---
 
-Fix HMR and support React Server Components.
+Fix HMR

--- a/.changeset/soft-lobsters-promise.md
+++ b/.changeset/soft-lobsters-promise.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Fix HMR and support React Server Components.

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -116,7 +116,7 @@ export function vanillaExtractPlugin({
       `;
     },
     async transform(code, id, ssrParam) {
-      if (!cssFileFilter.test(id)) {
+      if (!cssFileFilter.test(id.split('?')[0])) {
         return null;
       }
 

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -134,7 +134,7 @@ export function vanillaExtractPlugin({
         ssr = ssrParam?.ssr;
       }
 
-      if (ssr && !process.env.RSC_BUILD) {
+      if (ssr && !process.env.VITE_RSC_BUILD) {
         return addFileScope({
           source: code,
           filePath: normalizePath(validId),

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -131,7 +131,7 @@ export function vanillaExtractPlugin({
       const index = id.indexOf('?');
       const validId = index === -1 ? id : id.substring(0, index);
 
-      if (ssr) {
+      if (ssr && !process.env.RSC_BUILD) {
         return addFileScope({
           source: code,
           filePath: normalizePath(validId),


### PR DESCRIPTION
Hi! We are trying to support `vanilla-extract` in [`@shopify/hydrogen`](https://github.com/shopify/hydrogen) but we've found that the Vite plugin in this repo is not compatible with React Server Components.

I'm adding here some minimal changes that enable RSC support with the [plugin we are making here](https://github.com/facebook/react/pull/22952). Forking your plugin is also possible, if for any reason you don't want to support RSC yet.

- The first commit is, to my understanding, a bug fix. Vite uses sometimes `?v=42`-like query strings, and I think the regex checked in https://github.com/seek-oss/vanilla-extract/commit/0bc2b9fd4bf96e9cfef87b656ed225f9dae2c815 should pass regardless.
- The second commit adds an environment variable that is truthy when we do an RSC build. The main problem is that Vite doesn't have a way to differentiate between pure SSR build vs RSC build. That's why for now we need to give it a manual hint. With this variable, we are able to collect styles that are imported in server components.
- The third commit should fix https://github.com/seek-oss/vanilla-extract/issues/735.

Alternatively, I think it's also possible to use a plugin option instead of an env variable but we'd need to add public interface and some extra code.

cc @benjaminsehl @juanpprieto