### PR TITLE
Add scale to the list of unitless properties

### DIFF
--- a/.changeset/unitless-scale.md
+++ b/.changeset/unitless-scale.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/css': patch
+---
+
+Add `scale` to the list of unitless properties.

--- a/packages/css/src/transformCss.ts
+++ b/packages/css/src/transformCss.ts
@@ -50,6 +50,7 @@ const UNITLESS: Record<string, boolean> = {
   opacity: true,
   order: true,
   orphans: true,
+  scale: true,
   tabSize: true,
   WebkitLineClamp: true,
   widows: true,


### PR DESCRIPTION
I've noticed the following CSS is being generated when I set `scale: 1`:

<img width="156" alt="image" src="https://user-images.githubusercontent.com/242202/185394305-4ce21905-5d33-4fe9-bc22-4ce4da9725fa.png">

Scale [doesn't accept px](https://developer.mozilla.org/en-US/docs/Web/CSS/scale), so I think it should be added to the list of unitless properties.