### PR TITLE
chore(docs): Correct peerDeps for Gatsby integration

### DIFF
--- a/site/docs/integrations/gatsby.md
+++ b/site/docs/integrations/gatsby.md
@@ -10,7 +10,7 @@ A plugin for integrating vanilla-extract with [Gatsby](https://www.gatsbyjs.com)
 ## Installation
 
 ```bash
-npm install gatsby-plugin-vanilla-extract
+npm install gatsby-plugin-vanilla-extract @vanilla-extract/babel-plugin @vanilla-extract/css @vanilla-extract/webpack-plugin
 ```
 
 ## Setup


### PR DESCRIPTION
Hi!

I've added the needed `peerDeps` to the instructions because the Gatsby plugin doesn't install them for the user.