### PR TITLE
Fix `styleVariants` type when using the map data function

### DIFF
--- a/.changeset/brown-rice-draw.md
+++ b/.changeset/brown-rice-draw.md
@@ -1,0 +1,5 @@
+---
+"@vanilla-extract/css": patch
+---
+
+Fix `styleVariants` type when using the map data function

--- a/packages/css/src/style.ts
+++ b/packages/css/src/style.ts
@@ -137,9 +137,9 @@ export function globalKeyframes(name: string, rule: CSSKeyframes) {
 export function styleVariants<
   StyleMap extends Record<string | number, ComplexStyleRule>,
 >(styleMap: StyleMap, debugId?: string): Record<keyof StyleMap, string>;
-export function styleVariants<Data extends Record<string | number, unknown>>(
+export function styleVariants<Data extends Record<string | number, unknown>, Key extends keyof Data>(
   data: Data,
-  mapData: <Key extends keyof Data>(
+  mapData: (
     value: Data[Key],
     key: Key,
   ) => ComplexStyleRule,

--- a/packages/css/src/style.ts
+++ b/packages/css/src/style.ts
@@ -137,12 +137,12 @@ export function globalKeyframes(name: string, rule: CSSKeyframes) {
 export function styleVariants<
   StyleMap extends Record<string | number, ComplexStyleRule>,
 >(styleMap: StyleMap, debugId?: string): Record<keyof StyleMap, string>;
-export function styleVariants<Data extends Record<string | number, unknown>, Key extends keyof Data>(
+export function styleVariants<
+  Data extends Record<string | number, unknown>,
+  Key extends keyof Data,
+>(
   data: Data,
-  mapData: (
-    value: Data[Key],
-    key: Key,
-  ) => ComplexStyleRule,
+  mapData: (value: Data[Key], key: Key) => ComplexStyleRule,
   debugId?: string,
 ): Record<keyof Data, string>;
 export function styleVariants(...args: any[]) {


### PR DESCRIPTION
```ts
const vars = createThemeContract({
  info: {
    bgColor: null,
  },
  warn: {
    bgColor: null,
  },
  success: {
    bgColor: null,
  },
  error: {
    bgColor: null,
  }
});

export const staticCardStyles = styleVariants(
  vars,
  ({bgColor}) => [staticCard, { backgroundColor: bgColor }]
);
```

the error in my components lib is:
> Property 'bgColor' does not exist on type '`var(--${string})` | `var(--${string}, ${string})` | `var(--${string}, ${number})` | MapLeafNodes<{ info: { bgColor: null; }; warn: { bgColor: null; }; success: { bgColor: null; }; error: { bgColor: null; }; }[Key], CSSVarFunction>'.ts(2339)

when i fix the styleVariants's type, it's works well.
```ts
const vars = createThemeContract({
  info: {
    bgColor: null,
  },
  warn: {
    bgColor: null,
  },
  success: {
    bgColor: null,
  },
  error: {
    bgColor: null,
  }
});

export declare function styleVariants<Data extends Record<string | number, unknown>, Key extends keyof Data>(
  data: Data,
  mapData: (value: Data[Key], key: Key) => ComplexStyleRule,
  debugId?: string
): Record<keyof Data, string>;

export const staticCardStyles = styleVariants(
  vars,
  ({bgColor}) => [staticCard, { backgroundColor: bgColor }]
);
```

so, i think it related with typescript.