### PR TITLE
[Fix Document] Fix wrong props name

### DIFF
--- a/site/docs/overview/theming.md
+++ b/site/docs/overview/theming.md
@@ -212,7 +212,7 @@ const Container = ({
 );
 
 const App = () => (
-  <Container brand="pink" body="Arial">
+  <Container brandColor="pink" fontFamily="Arial">
     ...
   </Container>
 );

--- a/site/docs/packages/dynamic.md
+++ b/site/docs/packages/dynamic.md
@@ -96,7 +96,7 @@ const Container = ({
 );
 
 const App = () => (
-  <Container brand="pink" body="Arial">
+  <Container brandColor="pink" fontFamily="Arial">
     ...
   </Container>
 );


### PR DESCRIPTION
The name of the Container argument in the documentation seems to be wrong, so it has been corrected.