### PR TITLE
Use standard identifier generation logic for variable names

### DIFF
--- a/.changeset/gold-trainers-sing.md
+++ b/.changeset/gold-trainers-sing.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/css': patch
+---
+
+Fix spaces in debug IDs for variable names.

--- a/.changeset/hungry-ties-judge.md
+++ b/.changeset/hungry-ties-judge.md
@@ -2,7 +2,7 @@
 '@vanilla-extract/css': minor
 ---
 
-Support excluding file paths from `generateIdentifier` output. This is available by passing a newly-added options object rather than a string.
+Support excluding file names from `generateIdentifier` output. This is available by passing a newly-added options object rather than a string.
 
 **Example usage**
 
@@ -11,6 +11,6 @@ import { generateIdentifier } from '@vanilla-extract/css';
 
 const identifier = generateIdentifier({
   debugId,
-  includeFilePath: false,
+  debugFileName: false,
 });
 ```

--- a/.changeset/hungry-ties-judge.md
+++ b/.changeset/hungry-ties-judge.md
@@ -1,0 +1,16 @@
+---
+'@vanilla-extract/css': minor
+---
+
+Support excluding file paths from `generateIdentifier` output. This is available by passing a newly-added options object rather than a string.
+
+**Example usage**
+
+```ts
+import { generateIdentifier } from '@vanilla-extract/css';
+
+const identifier = generateIdentifier({
+  debugId,
+  includeFilePath: false,
+});
+```

--- a/.changeset/popular-seas-relate.md
+++ b/.changeset/popular-seas-relate.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/css': patch
+---
+
+Fix file name prefix in debug names when file extension is `.cjs` or `.mjs`.

--- a/packages/css/src/identifier.test.ts
+++ b/packages/css/src/identifier.test.ts
@@ -3,26 +3,58 @@ import { generateIdentifier } from './identifier';
 
 describe('identifier', () => {
   beforeAll(() => {
-    setFileScope('test');
+    setFileScope('test.css.ts');
   });
 
   afterAll(() => {
     endFileScope();
   });
 
-  it(`should create a valid identifier`, () => {
+  it(`should ignore file scopes without a file extension when creating a path prefix`, () => {
+    setFileScope('test');
     expect(generateIdentifier(undefined)).toMatchInlineSnapshot(`"skkcyc0"`);
+    endFileScope();
+  });
+
+  it(`should create a valid identifier`, () => {
+    expect(generateIdentifier(undefined)).toMatchInlineSnapshot(
+      `"test__q11bah0"`,
+    );
   });
 
   it('should create a valid identifier with a debug id', () => {
     expect(generateIdentifier('debug')).toMatchInlineSnapshot(
-      `"debug__skkcyc1"`,
+      `"test_debug__q11bah1"`,
     );
   });
 
   it('should create a valid identifier with a debug id with whitespace', () => {
     expect(generateIdentifier('debug and more')).toMatchInlineSnapshot(
-      `"debug_and_more__skkcyc2"`,
+      `"test_debug_and_more__q11bah2"`,
     );
+  });
+
+  describe('options object', () => {
+    it(`should create a valid identifier`, () => {
+      expect(generateIdentifier({})).toMatchInlineSnapshot(`"test__q11bah3"`);
+    });
+
+    it('should create a valid identifier with a debug id abd with file path explicitly enabled', () => {
+      expect(
+        generateIdentifier({ debugId: 'debug', includeFilePath: true }),
+      ).toMatchInlineSnapshot(`"test_debug__q11bah4"`);
+    });
+
+    it('should create a valid identifier with a debug id and without a file path', () => {
+      expect(
+        generateIdentifier({ debugId: 'debug', includeFilePath: false }),
+      ).toMatchInlineSnapshot(`"debug__q11bah5"`);
+    });
+
+    it('should create a valid identifier without a debug ID or file path', () => {
+      expect(
+        generateIdentifier({ includeFilePath: false }),
+      ).toMatchInlineSnapshot(`"q11bah6"`);
+    });
   });
 });

--- a/packages/css/src/identifier.test.ts
+++ b/packages/css/src/identifier.test.ts
@@ -3,7 +3,7 @@ import { generateIdentifier } from './identifier';
 
 describe('identifier', () => {
   beforeAll(() => {
-    setFileScope('test.css.ts');
+    setFileScope('path/to/file.css.ts');
   });
 
   afterAll(() => {
@@ -18,43 +18,43 @@ describe('identifier', () => {
 
   it(`should create a valid identifier`, () => {
     expect(generateIdentifier(undefined)).toMatchInlineSnapshot(
-      `"test__q11bah0"`,
+      `"file__18bazsm0"`,
     );
   });
 
   it('should create a valid identifier with a debug id', () => {
     expect(generateIdentifier('debug')).toMatchInlineSnapshot(
-      `"test_debug__q11bah1"`,
+      `"file_debug__18bazsm1"`,
     );
   });
 
   it('should create a valid identifier with a debug id with whitespace', () => {
     expect(generateIdentifier('debug and more')).toMatchInlineSnapshot(
-      `"test_debug_and_more__q11bah2"`,
+      `"file_debug_and_more__18bazsm2"`,
     );
   });
 
   describe('options object', () => {
     it(`should create a valid identifier`, () => {
-      expect(generateIdentifier({})).toMatchInlineSnapshot(`"test__q11bah3"`);
+      expect(generateIdentifier({})).toMatchInlineSnapshot(`"file__18bazsm3"`);
     });
 
-    it('should create a valid identifier with a debug id abd with file path explicitly enabled', () => {
+    it('should create a valid identifier with a debug id and with file name debugging explicitly enabled', () => {
       expect(
-        generateIdentifier({ debugId: 'debug', includeFilePath: true }),
-      ).toMatchInlineSnapshot(`"test_debug__q11bah4"`);
+        generateIdentifier({ debugId: 'debug', debugFileName: true }),
+      ).toMatchInlineSnapshot(`"file_debug__18bazsm4"`);
     });
 
-    it('should create a valid identifier with a debug id and without a file path', () => {
+    it('should create a valid identifier with a debug id and without file name debugging', () => {
       expect(
-        generateIdentifier({ debugId: 'debug', includeFilePath: false }),
-      ).toMatchInlineSnapshot(`"debug__q11bah5"`);
+        generateIdentifier({ debugId: 'debug', debugFileName: false }),
+      ).toMatchInlineSnapshot(`"debug__18bazsm5"`);
     });
 
-    it('should create a valid identifier without a debug ID or file path', () => {
+    it('should create a valid identifier without a debug ID or file name', () => {
       expect(
-        generateIdentifier({ includeFilePath: false }),
-      ).toMatchInlineSnapshot(`"q11bah6"`);
+        generateIdentifier({ debugFileName: false }),
+      ).toMatchInlineSnapshot(`"_18bazsm6"`);
     });
   });
 });

--- a/packages/css/src/identifier.ts
+++ b/packages/css/src/identifier.ts
@@ -16,7 +16,7 @@ function getDevPrefix({
     const { filePath } = getFileScope();
 
     const matches = filePath.match(
-      /(?<dir>[^\/\\]*)?[\/\\]?(?<file>[^\/\\]*)\.css\.(ts|js|tsx|jsx)$/,
+      /(?<dir>[^\/\\]*)?[\/\\]?(?<file>[^\/\\]*)\.css\.(ts|js|tsx|jsx|cjs|mjs)$/,
     );
 
     if (matches && matches.groups) {

--- a/packages/css/src/identifier.ts
+++ b/packages/css/src/identifier.ts
@@ -5,14 +5,14 @@ import { getAndIncrementRefCounter, getFileScope } from './fileScope';
 
 function getDevPrefix({
   debugId,
-  includeFilePath,
+  debugFileName,
 }: {
   debugId?: string;
-  includeFilePath: boolean;
+  debugFileName: boolean;
 }) {
   const parts = debugId ? [debugId.replace(/\s/g, '_')] : [];
 
-  if (includeFilePath) {
+  if (debugFileName) {
     const { filePath } = getFileScope();
 
     const matches = filePath.match(
@@ -30,7 +30,7 @@ function getDevPrefix({
 
 interface GenerateIdentifierOptions {
   debugId?: string;
-  includeFilePath?: boolean;
+  debugFileName?: boolean;
 }
 
 export function generateIdentifier(debugId?: string): string;
@@ -38,7 +38,7 @@ export function generateIdentifier(options?: GenerateIdentifierOptions): string;
 export function generateIdentifier(
   arg?: string | GenerateIdentifierOptions,
 ): string {
-  const { debugId, includeFilePath = true } = {
+  const { debugId, debugFileName = true } = {
     ...(typeof arg === 'string' ? { debugId: arg } : null),
     ...(typeof arg === 'object' ? arg : null),
   };
@@ -54,7 +54,7 @@ export function generateIdentifier(
   let identifier = `${fileScopeHash}${refCount}`;
 
   if (getIdentOption() === 'debug') {
-    const devPrefix = getDevPrefix({ debugId, includeFilePath });
+    const devPrefix = getDevPrefix({ debugId, debugFileName });
 
     if (devPrefix) {
       identifier = `${devPrefix}__${identifier}`;

--- a/packages/css/src/vars.ts
+++ b/packages/css/src/vars.ts
@@ -5,29 +5,20 @@ import {
   MapLeafNodes,
   CSSVarFunction,
 } from '@vanilla-extract/private';
-import hash from '@emotion/hash';
 import cssesc from 'cssesc';
 
 import { Tokens, NullableTokens, ThemeVars } from './types';
-import { getAndIncrementRefCounter, getFileScope } from './fileScope';
 import { validateContract } from './validateContract';
-import { getIdentOption } from './adapter';
+import { generateIdentifier } from './identifier';
 
 export function createVar(debugId?: string): CSSVarFunction {
-  // Convert ref count to base 36 for optimal hash lengths
-  const refCount = getAndIncrementRefCounter().toString(36);
-  const { filePath, packageName } = getFileScope();
-  const fileScopeHash = hash(
-    packageName ? `${packageName}${filePath}` : filePath,
+  const cssVarName = cssesc(
+    generateIdentifier({
+      debugId,
+      includeFilePath: false,
+    }),
+    { isIdentifier: true },
   );
-  const varName =
-    getIdentOption() === 'debug' && debugId
-      ? `${debugId}__${fileScopeHash}${refCount}`
-      : `${fileScopeHash}${refCount}`;
-
-  const cssVarName = cssesc(varName.match(/^[0-9]/) ? `_${varName}` : varName, {
-    isIdentifier: true,
-  });
 
   return `var(--${cssVarName})` as const;
 }

--- a/packages/css/src/vars.ts
+++ b/packages/css/src/vars.ts
@@ -15,7 +15,7 @@ export function createVar(debugId?: string): CSSVarFunction {
   const cssVarName = cssesc(
     generateIdentifier({
       debugId,
-      includeFilePath: false,
+      debugFileName: false,
     }),
     { isIdentifier: true },
   );


### PR DESCRIPTION
I was getting errors during development when my variable names contained spaces. Turns out it's because we weren't handling variable identifiers the same as everything else, instead manually reimplementing the `generateIdentifier` logic but forgetting to replace spaces with underscores.

To fix this, I've refactored `createVar` to use `generateIdentifier`, but since var debug names previously didn't have the file name prefix applied, I've also added an additional option to `generateIdentifier` to support turning this off, which `createVar` then uses. This is public API so I've added a changeset for it.

NOTE: This PR now includes a bonus fix, ensuring debug file names are present for `.cjs` and `.mjs` files.