### PR TITLE
Add experimental support for SolidStart to Vite plugin

### DIFF
--- a/.changeset/chilled-pets-help.md
+++ b/.changeset/chilled-pets-help.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': minor
+---
+
+Add experimental support for [SolidStart](https://github.com/solidjs/solid-start)

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -68,7 +68,11 @@ export function vanillaExtractPlugin({
         postCssConfig = await resolvePostcssConfig(config);
       }
 
-      if (config.plugins.some((p) => p.name === 'astro:build')) {
+      if (
+        config.plugins.some((plugin) =>
+          ['astro:build', 'solid-start-server'].includes(plugin.name),
+        )
+      ) {
         forceEmitCssInSsrBuild = true;
       }
     },


### PR DESCRIPTION
Turns out we can use the same approach for [SolidStart](https://github.com/solidjs/solid-start) that was used for Astro since they're both managing CSS during SSR in a similar way.