### PR TITLE
Fix entrypoint resolving in Vitest

### DIFF
--- a/.changeset/twelve-avocados-provide.md
+++ b/.changeset/twelve-avocados-provide.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/css': patch
+---
+
+Fix entrypoint resolving in Vitest

--- a/packages/css/adapter/package.json
+++ b/packages/css/adapter/package.json
@@ -5,5 +5,16 @@
     "./dist/vanilla-extract-css-adapter.cjs.js": "./dist/vanilla-extract-css-adapter.browser.cjs.js",
     "./dist/vanilla-extract-css-adapter.esm.js": "./dist/vanilla-extract-css-adapter.browser.esm.js"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "browser": {
+        "module": "./dist/vanilla-extract-css-adapter.browser.esm.js",
+        "default": "./dist/vanilla-extract-css-adapter.browser.cjs.js"
+      },
+      "module": "./dist/vanilla-extract-css-adapter.esm.js",
+      "default": "./dist/vanilla-extract-css-adapter.cjs.js"
+    }
+  }
 }

--- a/packages/css/disableRuntimeStyles/package.json
+++ b/packages/css/disableRuntimeStyles/package.json
@@ -4,5 +4,16 @@
   "browser": {
     "./dist/vanilla-extract-css-disableRuntimeStyles.cjs.js": "./dist/vanilla-extract-css-disableRuntimeStyles.browser.cjs.js",
     "./dist/vanilla-extract-css-disableRuntimeStyles.esm.js": "./dist/vanilla-extract-css-disableRuntimeStyles.browser.esm.js"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "browser": {
+        "module": "./dist/vanilla-extract-css-disableRuntimeStyles.browser.esm.js",
+        "default": "./dist/vanilla-extract-css-disableRuntimeStyles.browser.cjs.js"
+      },
+      "module": "./dist/vanilla-extract-css-disableRuntimeStyles.esm.js",
+      "default": "./dist/vanilla-extract-css-disableRuntimeStyles.cjs.js"
+    }
   }
 }

--- a/packages/css/fileScope/package.json
+++ b/packages/css/fileScope/package.json
@@ -5,5 +5,16 @@
     "./dist/vanilla-extract-css-fileScope.cjs.js": "./dist/vanilla-extract-css-fileScope.browser.cjs.js",
     "./dist/vanilla-extract-css-fileScope.esm.js": "./dist/vanilla-extract-css-fileScope.browser.esm.js"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "browser": {
+        "module": "./dist/vanilla-extract-css-fileScope.browser.esm.js",
+        "default": "./dist/vanilla-extract-css-fileScope.browser.cjs.js"
+      },
+      "module": "./dist/vanilla-extract-css-fileScope.esm.js",
+      "default": "./dist/vanilla-extract-css-fileScope.cjs.js"
+    }
+  }
 }

--- a/packages/css/functionSerializer/package.json
+++ b/packages/css/functionSerializer/package.json
@@ -4,5 +4,16 @@
   "browser": {
     "./dist/vanilla-extract-css-functionSerializer.cjs.js": "./dist/vanilla-extract-css-functionSerializer.browser.cjs.js",
     "./dist/vanilla-extract-css-functionSerializer.esm.js": "./dist/vanilla-extract-css-functionSerializer.browser.esm.js"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "browser": {
+        "module": "./dist/vanilla-extract-css-functionSerializer.browser.esm.js",
+        "default": "./dist/vanilla-extract-css-functionSerializer.browser.cjs.js"
+      },
+      "module": "./dist/vanilla-extract-css-functionSerializer.esm.js",
+      "default": "./dist/vanilla-extract-css-functionSerializer.cjs.js"
+    }
   }
 }

--- a/packages/css/injectStyles/package.json
+++ b/packages/css/injectStyles/package.json
@@ -4,5 +4,16 @@
   "browser": {
     "./dist/vanilla-extract-css-injectStyles.cjs.js": "./dist/vanilla-extract-css-injectStyles.browser.cjs.js",
     "./dist/vanilla-extract-css-injectStyles.esm.js": "./dist/vanilla-extract-css-injectStyles.browser.esm.js"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "browser": {
+        "module": "./dist/vanilla-extract-css-injectStyles.browser.esm.js",
+        "default": "./dist/vanilla-extract-css-injectStyles.browser.cjs.js"
+      },
+      "module": "./dist/vanilla-extract-css-injectStyles.esm.js",
+      "default": "./dist/vanilla-extract-css-injectStyles.cjs.js"
+    }
   }
 }

--- a/packages/css/recipe/package.json
+++ b/packages/css/recipe/package.json
@@ -4,5 +4,16 @@
   "browser": {
     "./dist/vanilla-extract-css-recipe.cjs.js": "./dist/vanilla-extract-css-recipe.browser.cjs.js",
     "./dist/vanilla-extract-css-recipe.esm.js": "./dist/vanilla-extract-css-recipe.browser.esm.js"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "browser": {
+        "module": "./dist/vanilla-extract-css-recipe.browser.esm.js",
+        "default": "./dist/vanilla-extract-css-recipe.browser.cjs.js"
+      },
+      "module": "./dist/vanilla-extract-css-recipe.esm.js",
+      "default": "./dist/vanilla-extract-css-recipe.cjs.js"
+    }
   }
 }

--- a/packages/css/transformCss/package.json
+++ b/packages/css/transformCss/package.json
@@ -5,5 +5,16 @@
     "./dist/vanilla-extract-css-transformCss.cjs.js": "./dist/vanilla-extract-css-transformCss.browser.cjs.js",
     "./dist/vanilla-extract-css-transformCss.esm.js": "./dist/vanilla-extract-css-transformCss.browser.esm.js"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "browser": {
+        "module": "./dist/vanilla-extract-css-transformCss.browser.esm.js",
+        "default": "./dist/vanilla-extract-css-transformCss.browser.cjs.js"
+      },
+      "module": "./dist/vanilla-extract-css-transformCss.esm.js",
+      "default": "./dist/vanilla-extract-css-transformCss.cjs.js"
+    }
+  }
 }


### PR DESCRIPTION
This PR gets .css.ts files working in the Vitest test runner. WIthout the `exports` definitions, Vitest was (stragely) resolving the ESM version of `@vanilla-extract/css` but the CJS version of `@vanilla-extract/css/fileScope`, causing filescope errors. 