### PR TITLE
Improve performance of transformCss with large amounts of class names

### DIFF
--- a/.changeset/ninety-windows-marry.md
+++ b/.changeset/ninety-windows-marry.md
@@ -4,4 +4,4 @@
 
 Improve performance of selector transforms
 
-This issue was especially prevalent on M1 Macs. 
+This issue occured on M1 Macs due to performance issues with large regex patterns. 

--- a/.changeset/ninety-windows-marry.md
+++ b/.changeset/ninety-windows-marry.md
@@ -2,4 +2,6 @@
 '@vanilla-extract/css': patch
 ---
 
-Improve performance of transformCss
+Improve performance of selector transforms
+
+This issue was especially prevalent on M1 Macs. 

--- a/.changeset/ninety-windows-marry.md
+++ b/.changeset/ninety-windows-marry.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/css': patch
+---
+
+Improve performance of transformCss

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -109,6 +109,7 @@
   "dependencies": {
     "@emotion/hash": "^0.8.0",
     "@vanilla-extract/private": "^1.0.3",
+    "ahocorasick": "^1.0.2",
     "chalk": "^4.1.1",
     "css-what": "^5.0.1",
     "cssesc": "^3.0.0",

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -109,7 +109,7 @@
   "dependencies": {
     "@emotion/hash": "^0.8.0",
     "@vanilla-extract/private": "^1.0.3",
-    "ahocorasick": "^1.0.2",
+    "ahocorasick": "1.0.2",
     "chalk": "^4.1.1",
     "css-what": "^5.0.1",
     "cssesc": "^3.0.0",

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -116,7 +116,6 @@
     "csstype": "^3.0.7",
     "deep-object-diff": "^1.1.0",
     "deepmerge": "^4.2.2",
-    "escape-string-regexp": "^4.0.0",
     "media-query-parser": "^2.0.2",
     "outdent": "^0.8.0"
   },

--- a/packages/css/src/ahocorasick.d.ts
+++ b/packages/css/src/ahocorasick.d.ts
@@ -1,0 +1,7 @@
+declare module 'ahocorasick' {
+  export default class Ahocorasick {
+    constructor(searchTerms: Array<string>);
+
+    search(input: string): Array<[endIndex: number, matches: Array<string>]>;
+  }
+}

--- a/packages/css/src/transformCss.test.ts
+++ b/packages/css/src/transformCss.test.ts
@@ -1564,4 +1564,30 @@ describe('transformCss', () => {
   });
 });
 
+it('should handle multiple references to the same locally scoped selector', () => {
+  expect(
+    transformCss({
+      composedClassLists: [],
+      localClassNames: ['testClass', 'parentClass'],
+      cssObjs: [
+        {
+          type: 'local',
+          selector: 'testClass',
+          rule: {
+            selectors: {
+              'parentClass &:before, parentClass &:after': {
+                background: 'black',
+              },
+            },
+          },
+        },
+      ],
+    }).join('\n'),
+  ).toMatchInlineSnapshot(`
+    ".parentClass .testClass:before, .parentClass .testClass:after {
+      background: black;
+    }"
+  `);
+});
+
 endFileScope();

--- a/packages/css/src/transformCss.test.ts
+++ b/packages/css/src/transformCss.test.ts
@@ -1571,7 +1571,7 @@ it('should handle multiple references to the same locally scoped selector', () =
   expect(
     transformCss({
       composedClassLists: [],
-      localClassNames: [style1, style2, '_1g1ptzo10', '_1g1ptzo1'],
+      localClassNames: [style1, style2, '_1g1ptzo1', '_1g1ptzo10'],
       cssObjs: [
         {
           type: 'local',
@@ -1585,6 +1585,10 @@ it('should handle multiple references to the same locally scoped selector', () =
               [`_1g1ptzo1_1g1ptzo10 ${style1}`]: {
                 background: 'blue',
               },
+
+              [`_1g1ptzo10_1g1ptzo1 ${style1}`]: {
+                background: 'blue',
+              },
             },
           },
         },
@@ -1595,6 +1599,9 @@ it('should handle multiple references to the same locally scoped selector', () =
       background: black;
     }
     ._1g1ptzo1._1g1ptzo10 .skkcyc1 {
+      background: blue;
+    }
+    ._1g1ptzo10._1g1ptzo1 .skkcyc1 {
       background: blue;
     }"
   `);

--- a/packages/css/src/transformCss.test.ts
+++ b/packages/css/src/transformCss.test.ts
@@ -1,10 +1,13 @@
 import { setFileScope, endFileScope } from './fileScope';
 import { createVar } from './vars';
 import { transformCss } from './transformCss';
+import { style } from './style';
 
 setFileScope('test');
 
 const testVar = createVar();
+const style1 = style({});
+const style2 = style({});
 
 describe('transformCss', () => {
   it('should escape class names', () => {
@@ -1568,15 +1571,19 @@ it('should handle multiple references to the same locally scoped selector', () =
   expect(
     transformCss({
       composedClassLists: [],
-      localClassNames: ['testClass', 'parentClass'],
+      localClassNames: [style1, style2, '_1g1ptzo10', '_1g1ptzo1'],
       cssObjs: [
         {
           type: 'local',
-          selector: 'testClass',
+          selector: style1,
           rule: {
             selectors: {
-              'parentClass &:before, parentClass &:after': {
+              [`${style2} &:before, ${style2} &:after`]: {
                 background: 'black',
+              },
+
+              [`_1g1ptzo1_1g1ptzo10 ${style1}`]: {
+                background: 'blue',
               },
             },
           },
@@ -1584,8 +1591,11 @@ it('should handle multiple references to the same locally scoped selector', () =
       ],
     }).join('\n'),
   ).toMatchInlineSnapshot(`
-    ".parentClass .testClass:before, .parentClass .testClass:after {
+    ".skkcyc2 .skkcyc1:before, .skkcyc2 .skkcyc1:after {
       background: black;
+    }
+    ._1g1ptzo1._1g1ptzo10 .skkcyc1 {
+      background: blue;
     }"
   `);
 });

--- a/packages/css/src/transformCss.ts
+++ b/packages/css/src/transformCss.ts
@@ -267,6 +267,12 @@ class Stylesheet {
     };
   }
 
+  transformClassname(identifier: string) {
+    return `.${cssesc(identifier, {
+      isIdentifier: true,
+    })}`;
+  }
+
   transformSelector(selector: string) {
     // Map class list compositions to single identifiers
     let transformedSelector = selector;
@@ -279,7 +285,7 @@ class Stylesheet {
     }
 
     if (this.localClassNamesMap.has(transformedSelector)) {
-      return `.${cssesc(transformedSelector, { isIdentifier: true })}`;
+      return this.transformClassname(transformedSelector);
     }
 
     const results = this.localClassNamesSearch.search(transformedSelector);
@@ -307,9 +313,7 @@ class Stylesheet {
           transformedSelector,
           startIndex,
           endIndex + 1,
-          `.${cssesc(firstMatch, {
-            isIdentifier: true,
-          })}`,
+          this.transformClassname(firstMatch),
         );
       }
     }

--- a/packages/css/src/transformCss.ts
+++ b/packages/css/src/transformCss.ts
@@ -290,22 +290,22 @@ class Stylesheet {
 
     const results = this.localClassNamesSearch.search(transformedSelector);
 
-    let lastReplace = transformedSelector.length;
+    let lastReplaceIndex = transformedSelector.length;
 
     // Perform replacements backwards to simplify index handling
     for (let i = results.length - 1; i >= 0; i--) {
       const [endIndex, [firstMatch]] = results[i];
       const startIndex = endIndex - firstMatch.length + 1;
 
-      if (lastReplace <= startIndex) {
+      if (startIndex >= lastReplaceIndex) {
         // Class names can be substrings of other class names
         // e.g. '_1g1ptzo1' and '_1g1ptzo10'
-        // If the last replaced index is <= startIndex, then
+        // If the startIndex >= lastReplaceIndex, then
         // this is the case and this replace should be skipped
         continue;
       }
 
-      lastReplace = startIndex;
+      lastReplaceIndex = startIndex;
 
       // If class names already starts with a '.' then skip
       if (transformedSelector[startIndex - 1] !== '.') {

--- a/packages/css/src/transformCss.ts
+++ b/packages/css/src/transformCss.ts
@@ -1,6 +1,7 @@
+import './ahocorasick';
+
 import { getVarName } from '@vanilla-extract/private';
 import cssesc from 'cssesc';
-// @ts-expect-error
 import AhoCorasick from 'ahocorasick';
 
 import type {
@@ -21,25 +22,6 @@ import { validateSelector } from './validateSelector';
 import { ConditionalRuleset } from './conditionalRulesets';
 import { simplePseudos, simplePseudoLookup } from './simplePseudos';
 import { validateMediaQuery } from './validateMediaQuery';
-
-// const replaceAll = (
-//   value: string,
-//   query: string,
-//   replacer: (index: number) => string,
-// ) => {
-//   let finalValue = value;
-//   let index = finalValue.indexOf(query);
-
-//   while (index !== -1) {
-//     const nextIndex = index + query.length;
-//     finalValue = `${finalValue.slice(0, index)}${replacer(
-//       index,
-//     )}${finalValue.slice(nextIndex)}`;
-//     index = finalValue.indexOf(query, nextIndex);
-//   }
-
-//   return finalValue;
-// };
 
 const UNITLESS: Record<string, boolean> = {
   animationIterationCount: true,
@@ -123,7 +105,7 @@ class Stylesheet {
   localClassNames: Array<string>;
   localClassNamesMap: Map<string, string>;
   composedClassLists: Array<{ identifier: string; regex: RegExp }>;
-  ac: any;
+  ac: AhoCorasick;
 
   constructor(
     localClassNames: Array<string>,

--- a/packages/css/src/transformCss.ts
+++ b/packages/css/src/transformCss.ts
@@ -102,10 +102,9 @@ class Stylesheet {
   currConditionalRuleset: ConditionalRuleset | undefined;
   fontFaceRules: Array<GlobalFontFaceRule>;
   keyframesRules: Array<CSSKeyframesBlock>;
-  localClassNames: Array<string>;
   localClassNamesMap: Map<string, string>;
+  localClassNamesSearch: AhoCorasick;
   composedClassLists: Array<{ identifier: string; regex: RegExp }>;
-  ac: AhoCorasick;
 
   constructor(
     localClassNames: Array<string>,
@@ -115,11 +114,10 @@ class Stylesheet {
     this.conditionalRulesets = [new ConditionalRuleset()];
     this.fontFaceRules = [];
     this.keyframesRules = [];
-    this.localClassNames = localClassNames;
     this.localClassNamesMap = new Map(
       localClassNames.map((localClassName) => [localClassName, localClassName]),
     );
-    this.ac = new AhoCorasick(localClassNames);
+    this.localClassNamesSearch = new AhoCorasick(localClassNames);
 
     // Class list compositions should be priortized by Newer > Older
     // Therefore we reverse the array as they are added in sequence
@@ -272,7 +270,7 @@ class Stylesheet {
       return `.${cssesc(transformedSelector, { isIdentifier: true })}`;
     }
 
-    const results = this.ac.search(transformedSelector);
+    const results = this.localClassNamesSearch.search(transformedSelector);
 
     let lastReplace = transformedSelector.length;
 

--- a/packages/css/src/transformCss.ts
+++ b/packages/css/src/transformCss.ts
@@ -292,9 +292,20 @@ class Stylesheet {
 
     const results = this.ac.search(transformedSelector);
 
+    let lastReplace = transformedSelector.length;
+
     for (let i = results.length - 1; i >= 0; i--) {
       const [endIndex, [firstMatch]] = results[i];
       const startIndex = endIndex - firstMatch.length + 1;
+
+      if (lastReplace <= startIndex) {
+        // Class names can be substrings of other class names
+        // If the last replcaed index is > startIndex, then
+        // this is the case and this replace should be skipped
+        continue;
+      }
+
+      lastReplace = startIndex;
 
       if (transformedSelector[startIndex - 1] !== '.') {
         transformedSelector = `${transformedSelector.slice(
@@ -305,20 +316,6 @@ class Stylesheet {
         })}${transformedSelector.slice(endIndex + 1)}`;
       }
     }
-
-    // for (const localClassName of this.localClassNames) {
-    //   transformedSelector = replaceAll(
-    //     transformedSelector,
-    //     localClassName,
-    //     (index) => {
-    //       if (transformedSelector[index - 1] === '.') {
-    //         return localClassName;
-    //       }
-
-    //       return `.${cssesc(localClassName, { isIdentifier: true })}`;
-    //     },
-    //   );
-    // }
 
     return transformedSelector;
   }

--- a/packages/css/src/transformCss.ts
+++ b/packages/css/src/transformCss.ts
@@ -294,7 +294,7 @@ class Stylesheet {
       if (lastReplace <= startIndex) {
         // Class names can be substrings of other class names
         // e.g. '_1g1ptzo1' and '_1g1ptzo10'
-        // If the last replcaed index is > startIndex, then
+        // If the last replaced index is > startIndex, then
         // this is the case and this replace should be skipped
         continue;
       }

--- a/packages/css/src/transformCss.ts
+++ b/packages/css/src/transformCss.ts
@@ -294,7 +294,7 @@ class Stylesheet {
       if (lastReplace <= startIndex) {
         // Class names can be substrings of other class names
         // e.g. '_1g1ptzo1' and '_1g1ptzo10'
-        // If the last replaced index is > startIndex, then
+        // If the last replaced index is <= startIndex, then
         // this is the case and this replace should be skipped
         continue;
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,7 +188,6 @@ importers:
       csstype: ^3.0.7
       deep-object-diff: ^1.1.0
       deepmerge: ^4.2.2
-      escape-string-regexp: ^4.0.0
       media-query-parser: ^2.0.2
       outdent: ^0.8.0
     dependencies:
@@ -201,7 +200,6 @@ importers:
       csstype: 3.0.10
       deep-object-diff: 1.1.0
       deepmerge: 4.2.2
-      escape-string-regexp: 4.0.0
       media-query-parser: 2.0.2
       outdent: 0.8.0
     devDependencies:
@@ -6573,11 +6571,6 @@ packages:
   /escape-string-regexp/2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
     engines: {node: '>=8'}
-    dev: false
-
-  /escape-string-regexp/4.0.0:
-    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
-    engines: {node: '>=10'}
     dev: false
 
   /escodegen/2.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,7 @@ importers:
       '@emotion/hash': ^0.8.0
       '@types/cssesc': ^3.0.0
       '@vanilla-extract/private': ^1.0.3
+      ahocorasick: ^1.0.2
       chalk: ^4.1.1
       css-what: ^5.0.1
       cssesc: ^3.0.0
@@ -193,6 +194,7 @@ importers:
     dependencies:
       '@emotion/hash': 0.8.0
       '@vanilla-extract/private': link:../private
+      ahocorasick: 1.0.2
       chalk: 4.1.2
       css-what: 5.1.0
       cssesc: 3.0.0
@@ -4376,6 +4378,10 @@ packages:
       debug: 4.3.2
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /ahocorasick/1.0.2:
+    resolution: {integrity: sha512-hCOfMzbFx5IDutmWLAt6MZwOUjIfSM9G9FyVxytmE4Rs/5YDPWQrD/+IR1w+FweD9H2oOZEnv36TmkjhNURBVA==}
     dev: false
 
   /ajv-errors/1.0.1_ajv@6.12.6:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,7 +181,7 @@ importers:
       '@emotion/hash': ^0.8.0
       '@types/cssesc': ^3.0.0
       '@vanilla-extract/private': ^1.0.3
-      ahocorasick: ^1.0.2
+      ahocorasick: 1.0.2
       chalk: ^4.1.1
       css-what: ^5.0.1
       cssesc: ^3.0.0
@@ -4628,7 +4628,7 @@ packages:
       loader-utils: 1.4.0
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.64.2_webpack-cli@4.9.1
+      webpack: 5.64.2_esbuild@0.11.23
 
   /babel-loader/8.2.3_webpack@5.64.2:
     resolution: {integrity: sha512-n4Zeta8NC3QAsuyiizu0GkmRcQ6clkV9WFUnUf1iXP//IeSKbWjofW3UHyZVwlOB4y039YQKefawyTn64Zwbuw==}
@@ -12394,7 +12394,6 @@ packages:
       source-map: 0.6.1
       terser: 5.10.0
       webpack: 5.64.2_esbuild@0.11.23
-    dev: false
 
   /terser-webpack-plugin/5.2.5_webpack@5.64.2:
     resolution: {integrity: sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==}
@@ -13475,7 +13474,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: false
 
   /webpack/5.64.2_webpack-cli@4.9.1:
     resolution: {integrity: sha512-4KGc0+Ozi0aS3EaLNRvEppfZUer+CaORKqL6OBjDLZOPf9YfN8leagFzwe6/PoBdHFxc/utKArl8LMC0Ivtmdg==}


### PR DESCRIPTION
When creating `.css.ts` files with large amounts of locally scoped classes, commonly encountered when using sprinkles, CSS output could be slow to create due to how selectors are transformed with large dynamic regular expressions. This issue was especially prevalent on M1 Macs. 

To resolve this, the old regular expression approach has been removed in favour of the following:
- In most cases, the selector being processed is just a single classname reference. In this case we don't need to search for all known local classnames and can be transformed whole after a single Map lookup. 
- In more complicated selectors, the RegExp approach has been removed in favour of using an Aho-Corasick based search, which is ideal for searching for multiple different keywords in text. 
  -  There aren't many libraries that implement this on NPM. `ahocorasick` seemed to be the best fit from a license, downloads and deps perspective. 

This change brings the [rainbowkit](https://github.com/rainbow-me/rainbowkit) start-up time down from ~180 seconds to ~12 seconds. 

Further optimisations can be done in future around caching CSS output more intelligently. However this will be explored in future PRs.  

Resolves #771 